### PR TITLE
[DLG-140] 배포 시, 컨테이너가 이미지 태그를 참조하도록 변경한다.

### DIFF
--- a/.github/workflows/dailyge-api-cd.yaml
+++ b/.github/workflows/dailyge-api-cd.yaml
@@ -1,4 +1,4 @@
-name: Dailyge Deploy
+name: Dailyge-Api Deploy
 
 on:
   pull_request:
@@ -9,7 +9,7 @@ on:
     paths:
       - dailyge-api/**
       - storage/**
-      - support**
+      - support/**
       - .github/workflows/**
 
 env:
@@ -103,7 +103,7 @@ jobs:
         with:
           task-definition: task-definition.json
           container-name: ${{ env.CONTAINER_NAME }}
-          image: ${{ env.ECR_URI }}:${{ steps.build-image.outputs.imageTag }}
+          image: ${{ env.ECR_URI }}:${{ env.IMAGE_TAG }}
 
       - name: Deploy ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1


### PR DESCRIPTION
## 📝 작업 내용

배포 시, 컨테이너가 이미지 태그를 참조하도록 변경했습니다.

- [x] 컨테이너 이미지 태그 참조하도록 배포 방식 변경

&nbsp; [[DLG-140]](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-140)
