### PR TITLE
[DLG-144] 부하 테스트를 위해 User Email 길이를 최대까지 허용한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/external/oauth/GoogleOAuthManager.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/external/oauth/GoogleOAuthManager.java
@@ -53,11 +53,12 @@ public class GoogleOAuthManager {
     }
 
     private GoogleUserInfoResponse returnMockUserInfo() {
-        final String uuid = UUID.randomUUID().toString();
-        final String name = uuid.substring(1, 25).replaceAll("-", "");
-        final String email = name + "@gmail.com";
+        final String firstUuid = UUID.randomUUID().toString().substring(0, 7).replace("-", "");
+        final String secondUuid = UUID.randomUUID().toString().replace("-", "");
+        final String email = firstUuid + secondUuid;
+        final String emailFormat = email + "@gmail.com";
         final String imageUrl = "https://shorturl.at/dejs2";
-        return new GoogleUserInfoResponse(uuid, name, email, imageUrl, true);
+        return new GoogleUserInfoResponse(secondUuid, emailFormat, emailFormat, imageUrl, true);
     }
 
     private GoogleAuthorizationResponse getAccessToken(final String code) {


### PR DESCRIPTION
## 📝 작업 내용

부하 테스트 시 발생하는 **`중복 Email 문제`** 를 해결하기위해, Email을 최대 길이(39)까지 사용합니다.

- [x] Email 길이 최대 39자로 변경

> 중복 Email 문제는 이미 존재하는 Email로 인해, INSERT가 되지 않는 문제입니다.

&nbsp; [[DLG-144]](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-144)
