### PR TITLE
[DLG-154] 로그인 된 사용자가 재 로그인을 시도할 때, 명시적으로 응답코드를 넣어준다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/web/LoginInterceptor.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/web/LoginInterceptor.java
@@ -18,8 +18,8 @@ import project.dailyge.app.core.user.external.oauth.TokenManager;
 import project.dailyge.core.cache.user.UserCache;
 import project.dailyge.core.cache.user.UserCacheReadUseCase;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.BAD_REQUEST;
 
 @Slf4j
 @Component
@@ -109,7 +109,7 @@ public class LoginInterceptor implements HandlerInterceptor {
         bodyMap.put("url", referer == null ? "/" : referer);
         bodyMap.put("Access-Token", accessToken);
 
-        response.setStatus(UNPROCESSABLE_ENTITY.value());
+        response.setStatus(BAD_REQUEST.code());
         response.setContentType(APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
         objectMapper.writeValue(response.getWriter(), bodyMap);

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/LoginInterceptorUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/LoginInterceptorUnitTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.BAD_REQUEST;
 import static project.dailyge.app.test.user.fixture.UserFixture.createUser;
 
 @DisplayName("[UnitTest] LoginInterceptor 단위 테스트")
@@ -77,7 +77,7 @@ class LoginInterceptorUnitTest {
             .thenReturn(true);
 
         assertFalse(loginInterceptor.preHandle(request, response, null));
-        assertEquals(UNPROCESSABLE_ENTITY.value(), response.getStatus());
+        assertEquals(BAD_REQUEST.code(), response.getStatus());
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용

이미 로그인한 사용자가 로그인 페이지를 호출하는 것은 클라이언트 오류로 판단하여 `400` 응답코드를 넣어주었습니다.

- [X] 로그인 된 사용자에게 명시적으로 응답코드 작성

&nbsp; [[DLG-154]](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-154)
