### PR TITLE
[DLG-178] Jib 설정을 추가한다.

### DIFF
--- a/dailyge-api/build.gradle
+++ b/dailyge-api/build.gradle
@@ -110,6 +110,8 @@ tasks.withType(JavaCompile).configureEach {
 
 tasks.named("jib").configure {
     dependsOn("copySubmoduleConfig")
+    dependsOn("openapi3")
+    dependsOn("copyDocument")
     enabled = true
 }
 


### PR DESCRIPTION
## 📝 작업 내용

Jib을 빌드하기 전, test가 실행되고 API 문서를 복사하도록 설정을 추가했습니다.

- [x] API 문서 복사 후 빌드 되도록 의존성 순서 정의

&nbsp; [[DLG-NUMBER]](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-NUMBER)
