### PR TITLE
[DLG-191] 일정 등록이 가능한 최대 기간을 5년 전/후로 수정한다.

### DIFF
--- a/storage/rdb/src/main/java/project/dailyge/entity/task/TaskJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/task/TaskJpaEntity.java
@@ -155,11 +155,7 @@ public class TaskJpaEntity extends BaseEntity {
         return OVER_MAX_CONTENT_LENGTH_ERROR_MESSAGE;
     }
 
-    public String getPastDateErrorMessage() {
-        return DATE_BETWEEN_BEFORE_OR_AFTER_ERROR_MESSAGE;
-    }
-
-    public String getBeyondOneYearErrorMessage() {
+    public String getDateErrorMessage() {
         return DATE_BETWEEN_BEFORE_OR_AFTER_ERROR_MESSAGE;
     }
 

--- a/storage/rdb/src/test/java/project/dailyge/entity/test/task/TaskJpaEntityUnitTest.java
+++ b/storage/rdb/src/test/java/project/dailyge/entity/test/task/TaskJpaEntityUnitTest.java
@@ -102,7 +102,8 @@ class TaskJpaEntityUnitTest {
                 .status(TODO)
                 .userId(1L)
                 .build()
-        ).isInstanceOf(IllegalArgumentException.class)
+        ).isInstanceOf(RuntimeException.class)
+            .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage(task.getOverMaxTitleLengthErrorMessage());
     }
 
@@ -120,12 +121,13 @@ class TaskJpaEntityUnitTest {
                 .status(TODO)
                 .userId(1L)
                 .build()
-        ).isInstanceOf(IllegalArgumentException.class)
+        ).isInstanceOf(RuntimeException.class)
+            .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining(task.getOverMaxContentLengthErrorMessage());
     }
 
     @Test
-    @DisplayName("5년 전/후 날짜를 입력하면 IllegalArgumentException가 발생한다.")
+    @DisplayName("5년 전 날짜를 입력하면 IllegalArgumentException가 발생한다.")
     void whenDateIsBeforeThenIllegalArgumentExceptionShouldBeOccur() {
         final LocalDate pastDate = LocalDate.now().minusYears(6);
 
@@ -137,8 +139,9 @@ class TaskJpaEntityUnitTest {
                 .status(TODO)
                 .userId(1L)
                 .build()
-        ).isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining(task.getPastDateErrorMessage());
+        ).isInstanceOf(RuntimeException.class)
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(task.getDateErrorMessage());
     }
 
     @Test
@@ -155,8 +158,9 @@ class TaskJpaEntityUnitTest {
                 .status(TODO)
                 .userId(1L)
                 .build()
-        ).isInstanceOf(IllegalArgumentException.class)
-            .hasMessageContaining(task.getBeyondOneYearErrorMessage());
+        ).isInstanceOf(RuntimeException.class)
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining(task.getDateErrorMessage());
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용

**`일정 등록이 가능한 최대 기간`** 을 **`오늘 날짜`** 를 기준으로 5년 전/후로 수정했습니다. 

- [x] 일정 등록이 가능한 최대 기간을 5년 전/후로 수정
- [x] 깨진 테스트 복구

&nbsp; [[DLG-191]](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-191)
