### PR TITLE
[DLG-211] 스키마 스크립트를 수정한다.

### DIFF
--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -31,14 +31,14 @@ CREATE TABLE IF NOT EXISTS tasks
     `year`           INT                                  NOT NULL COMMENT '년',
     `date`           DATE                                 NOT NULL COMMENT '날짜',
     status           ENUM ('TODO', 'IN_PROGRESS', 'DONE') NOT NULL COMMENT '할 일 상태',
+    color            varchar(255)                         NOT NULL COMMENT '할 일 색상',
+    monthly_task_id  BIGINT                               NOT NULL COMMENT '월간 일정',
     created_at       DATETIME(6)                          NOT NULL COMMENT '생성일',
     created_by       BIGINT                               NULL COMMENT '생성한 사람',
     last_modified_at DATETIME(6)                          NULL COMMENT '최종 수정일',
     last_modified_by BIGINT                               NULL COMMENT '최종 수정한 사람',
-    deleted          BIT                                  NOT NULL COMMENT '삭제 유무',
-    color            varchar(255)                         NULL,
-    monthly_task_id  BIGINT                               NULL
-    ) engine 'InnoDB' COMMENT '할 일';
+    deleted          BIT                                  NOT NULL COMMENT '삭제 유무'
+) engine 'InnoDB' COMMENT '할 일';
 
 DROP TABLE IF EXISTS users;
 CREATE TABLE IF NOT EXISTS users
@@ -103,8 +103,8 @@ CREATE TABLE IF NOT EXISTS free_coupons
     deleted          BIT                               NOT NULL DEFAULT 0 COMMENT '삭제 여부'
 ) ENGINE = InnoDB COMMENT '무료 쿠폰';
 
-DROP TABLE IF EXISTS monthly_gols;
-CREATE TABLE IF NOT EXISTS monthly_gols
+DROP TABLE IF EXISTS monthly_goals;
+CREATE TABLE IF NOT EXISTS monthly_goals
 (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '월간 목표 ID',
     title            VARCHAR(50)                       NOT NULL COMMENT '제목',

--- a/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
+++ b/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
@@ -8,13 +8,13 @@ CREATE TABLE IF NOT EXISTS tasks
     `year`           INT                                  NOT NULL COMMENT '년',
     `date`           DATE                                 NOT NULL COMMENT '날짜',
     status           ENUM ('TODO', 'IN_PROGRESS', 'DONE') NOT NULL COMMENT '할 일 상태',
+    color            varchar(255)                         NOT NULL COMMENT '할 일 색상',
+    monthly_task_id  BIGINT                               NOT NULL COMMENT '월간 일정',
     created_at       DATETIME(6)                          NOT NULL COMMENT '생성일',
     created_by       BIGINT                               NULL COMMENT '생성한 사람',
     last_modified_at DATETIME(6)                          NULL COMMENT '최종 수정일',
     last_modified_by BIGINT                               NULL COMMENT '최종 수정한 사람',
-    deleted          BIT                                  NOT NULL COMMENT '삭제 유무',
-    color            varchar(255)                         NULL,
-    monthly_task_id  BIGINT                               NULL
+    deleted          BIT                                  NOT NULL COMMENT '삭제 유무'
 ) engine 'InnoDB' COMMENT '할 일';
 
 CREATE TABLE IF NOT EXISTS user_sequence
@@ -39,8 +39,8 @@ CREATE TABLE IF NOT EXISTS users
     deleted_at        DATETIME(6)              NULL COMMENT '삭제일'
 ) engine 'InnoDB' COMMENT '사용자';
 
-DROP TABLE IF EXISTS monthly_gols;
-CREATE TABLE IF NOT EXISTS monthly_gols
+DROP TABLE IF EXISTS monthly_goals;
+CREATE TABLE IF NOT EXISTS monthly_goals
 (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '월간 목표 ID',
     title            VARCHAR(50)                       NOT NULL COMMENT '제목',


### PR DESCRIPTION
## 📝 작업 내용

기존에 tasks 테이블 프라이머리 키와 엔티티와 실제 운영 DB 테이블 구조가 일치하지 않아서 서버오류가 발생했습니다. 이를 반영하기 위해 sql 스크립트를 수정하게 되었습니다.

- [X] tasks 테이블 컬럼 추가
- [X] 스크립트 오타 수정 및 column 조건 추가

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-211)
