### PR TITLE
[DLG-278] JWT 내부에 email 정보를 제거한다.

### DIFF
--- a/admin-api/src/main/java/project/dailyge/app/common/auth/TokenProvider.java
+++ b/admin-api/src/main/java/project/dailyge/app/common/auth/TokenProvider.java
@@ -36,12 +36,9 @@ public class TokenProvider {
     private final JwtProperties jwtProperties;
     private final SecretKeyManager secretKeyManager;
 
-    public DailygeToken createToken(
-        final Long userId,
-        final String userEmail
-    ) {
-        final String accessToken = generateToken(userId, userEmail, getExpiry(jwtProperties.getAccessExpiredTime()));
-        final String refreshToken = generateToken(userId, userEmail, getExpiry(jwtProperties.getRefreshExpiredTime()));
+    public DailygeToken createToken(final Long userId) {
+        final String accessToken = generateToken(userId, getExpiry(jwtProperties.getAccessExpiredTime()));
+        final String refreshToken = generateToken(userId, getExpiry(jwtProperties.getRefreshExpiredTime()));
         return new DailygeToken(accessToken, refreshToken, jwtProperties.getAccessExpiredTime(), jwtProperties.getRefreshExpiredTime());
     }
 
@@ -52,14 +49,12 @@ public class TokenProvider {
 
     private String generateToken(
         final Long userId,
-        final String userEmail,
         final Date expiry
     ) {
         try {
             return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setExpiration(expiry)
-                .setSubject(userEmail)
                 .claim(ID, encryptUserId(userId))
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
                 .compact();

--- a/admin-api/src/test/java/project/dailyge/app/test/common/AuthArgumentResolverTest.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/common/AuthArgumentResolverTest.java
@@ -55,7 +55,7 @@ class AuthArgumentResolverTest {
     @DisplayName("ID와 토큰정보가 존재하고, 올바르다면 인증 객체가 생성된다.")
     void whenTokenAndUserIdIsValidThenResultShouldBeNotNull() {
         final UserJpaEntity user = UserFixture.createUser(1L);
-        final DailygeToken token = tokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken token = tokenProvider.createToken(user.getId());
         final Cookie[] cookies = new Cookie[1];
         cookies[0] = new Cookie("Access-Token", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);
@@ -86,7 +86,7 @@ class AuthArgumentResolverTest {
     void whenUserIdIsValidThenResultShouldNotThrowException() {
         final Long validUserId = 456L;
         final UserJpaEntity expectedUser = UserFixture.createUser(validUserId);
-        final DailygeToken token = tokenProvider.createToken(expectedUser.getId(), expectedUser.getEmail());
+        final DailygeToken token = tokenProvider.createToken(expectedUser.getId());
         final Cookie[] cookies = new Cookie[1];
         cookies[0] = new Cookie("Access-Token", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);

--- a/admin-api/src/test/java/project/dailyge/app/test/common/TokenProviderUnitTest.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/common/TokenProviderUnitTest.java
@@ -44,7 +44,7 @@ class TokenProviderUnitTest {
     @DisplayName("사용자 토큰을 생성하면, 토큰이 정상적으로 생성된다.")
     void whenCreateUserTokenThenResultShouldBeNotNull() {
         final UserJpaEntity user = UserFixture.createUser(1L);
-        final DailygeToken token = tokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken token = tokenProvider.createToken(user.getId());
 
         assertAll(
             () -> assertNotNull(token),
@@ -60,7 +60,7 @@ class TokenProviderUnitTest {
     @DisplayName("사용자 토큰이 올바르다면, 사용자 ID를 얻는다.")
     void whenUserTokenCorrectThenUserIdShouldBeNotNull() {
         final UserJpaEntity user = UserFixture.createUser(1L);
-        final DailygeToken token = tokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken token = tokenProvider.createToken(user.getId());
 
         assertEquals(user.getId(), tokenProvider.getUserId(token.accessToken()));
     }

--- a/admin-api/src/test/java/project/dailyge/app/test/notice/documentationtest/NoticeCreateDocumentation.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/notice/documentationtest/NoticeCreateDocumentation.java
@@ -44,7 +44,7 @@ class NoticeCreateDocumentation extends DatabaseTestBase {
     void setUp() {
         final UserCache adminUser = new UserCache(ADMIN_ID, "admin", ADMIN_EMAIL, "", Role.ADMIN.name());
         userCacheWriteUseCase.save(adminUser);
-        token = tokenProvider.createToken(ADMIN_ID, ADMIN_EMAIL);
+        token = tokenProvider.createToken(ADMIN_ID);
         request = new NoticeCreateRequest("공지사항 제목", CONTENT, UPDATE);
         adminCookie = new Cookie.Builder("Access-Token", token.accessToken()).build();
     }

--- a/admin-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserBlacklistCreateDocumentation.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserBlacklistCreateDocumentation.java
@@ -44,7 +44,7 @@ class UserBlacklistCreateDocumentation extends DatabaseTestBase {
     void setUp() {
         final UserCache admin = new UserCache(ADMIN_ID, "admin", ADMIN_EMAIL, "", Role.ADMIN.name());
         userCacheWriteUseCase.save(admin);
-        token = tokenProvider.createToken(ADMIN_ID, ADMIN_EMAIL);
+        token = tokenProvider.createToken(ADMIN_ID);
         request = new UserBlacklistCreateRequest("accessToken");
         adminCookie = new Cookie.Builder("Access-Token", token.accessToken()).build();
     }

--- a/dailyge-api/src/main/java/project/dailyge/app/common/auth/TokenProvider.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/auth/TokenProvider.java
@@ -32,20 +32,15 @@ import java.util.Date;
 public class TokenProvider {
 
     private static final String ID = "id";
-    private static final String BEARER = "Bearer ";
-    private static final int TOKEN_BEGIN_INDEX = 7;
     private static final SecureRandom secureRandom = new SecureRandom();
     private static final int ARRAY_START_INDEX = 0;
     private static final int IV_SIZE = 16;
     private final JwtProperties jwtProperties;
     private final SecretKeyManager secretKeyManager;
 
-    public DailygeToken createToken(
-        final Long userId,
-        final String userEmail
-    ) {
-        final String accessToken = generateToken(userId, userEmail, getExpiry(jwtProperties.getAccessExpiredTime()));
-        final String refreshToken = generateToken(userId, userEmail, getExpiry(jwtProperties.getRefreshExpiredTime()));
+    public DailygeToken createToken(final Long userId) {
+        final String accessToken = generateToken(userId, getExpiry(jwtProperties.getAccessExpiredTime()));
+        final String refreshToken = generateToken(userId, getExpiry(jwtProperties.getRefreshExpiredTime()));
         return new DailygeToken(accessToken, refreshToken, jwtProperties.getAccessExpiredTime(), jwtProperties.getRefreshExpiredTime());
     }
 
@@ -56,14 +51,12 @@ public class TokenProvider {
 
     private String generateToken(
         final Long userId,
-        final String userEmail,
         final Date expiry
     ) {
         try {
             return Jwts.builder()
                 .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
                 .setExpiration(expiry)
-                .setSubject(userEmail)
                 .claim(ID, encryptUserId(userId))
                 .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
                 .compact();

--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/web/LoginInterceptor.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/web/LoginInterceptor.java
@@ -74,7 +74,7 @@ public class LoginInterceptor implements HandlerInterceptor {
                 return true;
             }
 
-            final DailygeToken token = tokenProvider.createToken(userCache.getId(), userCache.getEmail());
+            final DailygeToken token = tokenProvider.createToken(userCache.getId());
             setLoggedInResponse(request, response, token.accessToken());
             return false;
         } catch (Exception ex) {

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/facade/UserFacade.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/facade/UserFacade.java
@@ -40,7 +40,7 @@ public class UserFacade {
         final GoogleUserInfoResponse response = googleOAuthManager.getUserInfo(code);
         final Long findUserId = userReadUseCase.findUserIdByEmail(response.getEmail());
         final Long userId = publishEvent(findUserId, response);
-        final DailygeToken token = tokenProvider.createToken(userId, response.getEmail());
+        final DailygeToken token = tokenProvider.createToken(userId);
         tokenManager.saveRefreshToken(userId, token.refreshToken());
         return token;
     }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/AuthArgumentResolverTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/AuthArgumentResolverTest.java
@@ -56,7 +56,7 @@ class AuthArgumentResolverTest {
     @DisplayName("토큰정보가 존재하고, 올바르다면 인증 객체가 생성된다.")
     void shouldBeNotNullWhenUserIdIsValid() {
         final UserJpaEntity user = UserFixture.createUser(1L);
-        final DailygeToken token = tokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken token = tokenProvider.createToken(user.getId());
         final Cookie[] cookies = new Cookie[1];
         cookies[0] = new Cookie("Access-Token", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);
@@ -87,7 +87,7 @@ class AuthArgumentResolverTest {
     void shouldNotThrowExceptionWhenUserIdIsValid() {
         final Long validUserId = 456L;
         final UserJpaEntity expectedUser = UserFixture.createUser(validUserId);
-        final DailygeToken token = tokenProvider.createToken(expectedUser.getId(), expectedUser.getEmail());
+        final DailygeToken token = tokenProvider.createToken(expectedUser.getId());
         final Cookie[] cookies = new Cookie[1];
         cookies[0] = new Cookie("Access-Token", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/LoginInterceptorUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/LoginInterceptorUnitTest.java
@@ -67,7 +67,7 @@ class LoginInterceptorUnitTest {
     @DisplayName("로그인 사용자가 로그인 호출 시, false 를 반환한다.")
     void whenLoginUserCallsToLoginThenResultShouldBeFalse() {
         final UserJpaEntity user = createUser(1L);
-        final DailygeToken token = tokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken token = tokenProvider.createToken(user.getId());
 
         final Cookie[] cookies = new Cookie[1];
         cookies[0] = new Cookie("Access-Token", token.accessToken());
@@ -83,9 +83,9 @@ class LoginInterceptorUnitTest {
     @DisplayName("토큰 기간이 만료된 사용자는 재갱신하고, false 를 반환한다.")
     void whenSuccessRefreshForExpiredUserThenResultShouldBeFalse() throws UnsupportedEncodingException, JSONException {
         final UserJpaEntity user = createUser(1L);
-        final DailygeToken token = tokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken token = tokenProvider.createToken(user.getId());
         final TokenProvider expiredTokenProvider = new TokenProvider(expiredJwtProperties, secretKeyManager);
-        final DailygeToken expiredToken = expiredTokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken expiredToken = expiredTokenProvider.createToken(user.getId());
         final Cookie[] cookies = new Cookie[2];
         cookies[0] = new Cookie("Refresh-Token", token.refreshToken());
         cookies[1] = new Cookie("Access-Token", expiredToken.accessToken());
@@ -116,7 +116,7 @@ class LoginInterceptorUnitTest {
     void whenFailedRefreshForExpiredUserThenResultShouldBeTrue() {
         final TokenProvider expiredTokenProvider = new TokenProvider(expiredJwtProperties, secretKeyManager);
         final UserJpaEntity user = createUser(1L);
-        final DailygeToken expiredToken = expiredTokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken expiredToken = expiredTokenProvider.createToken(user.getId());
         final Cookie[] cookies = new Cookie[2];
         cookies[0] = new Cookie("Refresh-Token", null);
         cookies[1] = new Cookie("Access-Token", expiredToken.accessToken());

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/TokenProviderUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/TokenProviderUnitTest.java
@@ -44,7 +44,7 @@ class TokenProviderUnitTest {
     @DisplayName("사용자 토큰을 생성하면, 토큰이 정상적으로 생성된다.")
     void whenCreateUserTokenThenResultShouldBeNotNull() {
         final UserJpaEntity user = UserFixture.createUser(1L);
-        final DailygeToken token = tokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken token = tokenProvider.createToken(user.getId());
 
         assertAll(
             () -> assertNotNull(token),
@@ -59,7 +59,7 @@ class TokenProviderUnitTest {
     @DisplayName("사용자 토큰이 올바르다면, 사용자 ID를 얻는다.")
     void whenUserTokenCorrectThenUserIdShouldBeNotNull() {
         final UserJpaEntity user = UserFixture.createUser(1L);
-        final DailygeToken token = tokenProvider.createToken(user.getId(), user.getEmail());
+        final DailygeToken token = tokenProvider.createToken(user.getId());
 
         assertEquals(user.getId(), tokenProvider.getUserId(token.accessToken()));
     }


### PR DESCRIPTION
## 📝 작업 내용

JWT 내부에 불필요한 사용자 정보인 email 정보를 제거하였습니다.

- [X] JWT 내부 email 정보 제거

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-278)
