### PR TITLE
[DLG-306] LuaScript를 Redis에 등록하고 EVALSHA로 실행한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/common/configuration/script/LuaScript.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/configuration/script/LuaScript.java
@@ -5,14 +5,11 @@ public interface LuaScript {
         "local cache_key = KEYS[1] "
             + "local blacklist_key = KEYS[2] "
             + "local cache = redis.call('GET', cache_key) "
-            + "if cache then "
-            + "    local is_blacklisted = redis.call('EXISTS', blacklist_key) "
-            + "    if is_blacklisted == 1 then "
-            + "        return nil "
-            + "    else "
-            + "        return cache "
-            + "    end "
-            + "else "
+            + "if not cache then "
             + "    return nil "
-            + "end";
+            + "end "
+            + "if redis.call('EXISTS', blacklist_key) == 1 then "
+            + "    return nil "
+            + "end "
+            + "return cache ";
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/common/configuration/script/LuaScriptConfig.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/configuration/script/LuaScriptConfig.java
@@ -1,18 +1,28 @@
 package project.dailyge.app.common.configuration.script;
 
+import io.lettuce.core.RedisException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.BAD_GATEWAY;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.INTERNAL_SERVER_ERROR;
 import static project.dailyge.app.common.configuration.script.LuaScript.USER_CACHE_SEARCH_LUA_SCRIPT;
+import project.dailyge.app.common.exception.CommonException;
 
 @Configuration
 public class LuaScriptConfig {
 
     @Bean
-    public DefaultRedisScript<byte[]> userCacheSearchScript() {
-        final DefaultRedisScript<byte[]> script = new DefaultRedisScript<>();
-        script.setScriptText(USER_CACHE_SEARCH_LUA_SCRIPT);
-        script.setResultType(byte[].class);
-        return script;
+    public String scriptSha(final RedisTemplate<String, byte[]> redisTemplate) {
+        try {
+            return redisTemplate.execute((RedisCallback<String>) connection ->
+                connection.scriptingCommands().scriptLoad(USER_CACHE_SEARCH_LUA_SCRIPT.getBytes())
+            );
+        } catch (RedisException ex) {
+            throw CommonException.from(ex.getMessage(), BAD_GATEWAY);
+        } catch (Exception ex) {
+            throw CommonException.from(ex.getMessage(), INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/persistence/UserCacheReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/persistence/UserCacheReadDao.java
@@ -2,15 +2,18 @@ package project.dailyge.app.core.user.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.lettuce.core.RedisException;
-import static java.util.Arrays.asList;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.RedisSystemException;
+import static org.springframework.data.redis.connection.ReturnType.VALUE;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Repository;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.BAD_GATEWAY;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.INTERNAL_SERVER_ERROR;
+import static project.dailyge.app.common.configuration.script.LuaScript.USER_CACHE_SEARCH_LUA_SCRIPT;
 import project.dailyge.app.common.exception.CommonException;
 import static project.dailyge.common.configuration.CompressionHelper.decompressAsObjWithZstd;
+import static project.dailyge.common.exception.RedisExceptionUtils.resolveRedisSystemException;
 import project.dailyge.core.cache.user.UserCache;
 import project.dailyge.core.cache.user.UserCacheReadRepository;
 
@@ -19,17 +22,22 @@ import project.dailyge.core.cache.user.UserCacheReadRepository;
 public class UserCacheReadDao implements UserCacheReadRepository {
 
     private final RedisTemplate<String, byte[]> redisTemplate;
-    private final DefaultRedisScript<byte[]> script;
+    private final String scriptSha;
     private final ObjectMapper objectMapper;
 
     @Override
     public UserCache findById(final Long userId) {
         try {
-            final byte[] findCache = redisTemplate.execute(script, asList(getCacheKey(userId), getBlacklistKey(userId)));
+            final byte[] findCache = redisTemplate.execute((RedisCallback<byte[]>) connection ->
+                connection.scriptingCommands()
+                    .evalSha(scriptSha, VALUE, 2, getCacheKey(userId).getBytes(), getBlacklistKey(userId).getBytes()));
             if (findCache == null || findCache.length == 0) {
                 return null;
             }
             return decompressAsObjWithZstd(findCache, UserCache.class, objectMapper);
+        } catch (RedisSystemException ex) {
+            resolveRedisSystemException(ex.getMessage(), getReRegisterScriptExecution());
+            throw CommonException.from(ex.getMessage(), BAD_GATEWAY);
         } catch (RedisException ex) {
             throw CommonException.from(ex.getMessage(), BAD_GATEWAY);
         } catch (Exception ex) {
@@ -49,11 +57,23 @@ public class UserCacheReadDao implements UserCacheReadRepository {
         }
     }
 
-    private static String getCacheKey(Long userId) {
+    private static String getCacheKey(final Long userId) {
         return String.format("user:cache:%s", userId);
     }
 
-    private static String getBlacklistKey(Long userId) {
+    private static String getBlacklistKey(final Long userId) {
         return String.format("user:blacklist:%s", userId);
+    }
+
+    private Runnable getReRegisterScriptExecution() {
+        try {
+            return () -> redisTemplate.execute((RedisCallback<String>) connection ->
+                connection.scriptingCommands().scriptLoad(USER_CACHE_SEARCH_LUA_SCRIPT.getBytes())
+            );
+        } catch (RedisException ex) {
+            throw CommonException.from(ex.getMessage(), BAD_GATEWAY);
+        } catch (Exception ex) {
+            throw CommonException.from(ex.getMessage(), INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/dailyge-api/src/test/java/project/dailyge/app/common/DatabaseTestBase.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/common/DatabaseTestBase.java
@@ -22,20 +22,18 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 import project.dailyge.app.DailygeApplication;
+import static project.dailyge.app.common.RestAssureConfig.initObjectMapper;
+import static project.dailyge.app.common.RestAssureConfig.initSpecificationConfig;
 import project.dailyge.app.common.auth.DailygeUser;
 import project.dailyge.app.core.user.application.UserWriteUseCase;
+import static project.dailyge.app.test.user.fixture.UserFixture.EMAIL;
+import static project.dailyge.app.test.user.fixture.UserFixture.createUser;
 import project.dailyge.core.cache.user.UserCache;
 import project.dailyge.core.cache.user.UserCacheWriteUseCase;
+import static project.dailyge.entity.user.Role.NORMAL;
 import project.dailyge.entity.user.UserJpaEntity;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-
-import static project.dailyge.app.common.RestAssureConfig.initObjectMapper;
-import static project.dailyge.app.common.RestAssureConfig.initSpecificationConfig;
-import static project.dailyge.app.test.user.fixture.UserFixture.EMAIL;
-import static project.dailyge.app.test.user.fixture.UserFixture.createUser;
-import static project.dailyge.entity.user.Role.NORMAL;
 
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
@@ -50,7 +48,6 @@ public abstract class DatabaseTestBase {
 
     protected static final String IDENTIFIER = "{class_name}/{method_name}";
     protected static final String USER_ID_KEY = "dailyge_user_id";
-    protected static final String AUTHORIZATION = "Authorization";
 
     @LocalServerPort
     protected int port;
@@ -92,7 +89,7 @@ public abstract class DatabaseTestBase {
     }
 
     @AfterEach
-    void afterEach() {
+    protected void afterEach() {
         RestAssured.reset();
     }
 
@@ -101,7 +98,7 @@ public abstract class DatabaseTestBase {
     }
 
     @Transactional
-    protected UserJpaEntity persist(final UserJpaEntity user) {
+    protected void persist(final UserJpaEntity user) {
         userWriteUseCase.save(user);
         newUser = user;
         final UserCache userCache = new UserCache(
@@ -113,7 +110,6 @@ public abstract class DatabaseTestBase {
         );
         userCacheWriteUseCase.save(userCache);
         dailygeUser = new DailygeUser(user.getId(), user.getRole());
-        return user;
     }
 
     protected Cookie getCouponCookie() {

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/integrationtest/UserCacheReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/integrationtest/UserCacheReadIntegrationTest.java
@@ -4,23 +4,27 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import static java.lang.System.nanoTime;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import project.dailyge.app.common.DatabaseTestBase;
-import project.dailyge.app.core.user.persistence.UserCacheReadDao;
+import project.dailyge.app.common.exception.CommonException;
 import project.dailyge.app.core.user.persistence.UserCacheWriteDao;
 import static project.dailyge.common.configuration.CompressionHelper.compressAsByteArrayWithZstd;
 import static project.dailyge.common.configuration.CompressionHelper.decompressAsObjWithZstd;
 import project.dailyge.core.cache.user.UserCache;
+import project.dailyge.core.cache.user.UserCacheReadUseCase;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,13 +41,66 @@ class UserCacheReadIntegrationTest extends DatabaseTestBase {
     private UserCacheWriteDao userCacheWriteDao;
 
     @Autowired
-    private UserCacheReadDao userCacheReadDao;
+    private UserCacheReadUseCase userCacheReadUseCase;
 
     @Autowired
     private ObjectMapper objectMapper;
 
     @Autowired
     private RedisTemplate<String, byte[]> redisTemplate;
+
+    @Autowired
+    private String scriptSha;
+
+    private final String script = "local cache_key = KEYS[1] "
+        + "local blacklist_key = KEYS[2] "
+        + "local cache = redis.call('GET', cache_key) "
+        + "if not cache then "
+        + "    return nil "
+        + "end "
+        + "if redis.call('EXISTS', blacklist_key) == 1 then "
+        + "    return nil "
+        + "end "
+        + "return cache ";
+
+    @AfterEach
+    void afterEach() {
+        flushScript();
+        loadScriptAndGetSha();
+    }
+
+    @Test
+    @DisplayName("레디스 서버 다운으로 스크립트가 초기화가 된 후, 재 등록하면 해시 값은 언제나 동일하다.")
+    public void givenRedisServerDownAndFlushedScriptWhenReRegisterScriptThenHashMustBeEquals() {
+        final String originSha1 = loadScriptAndGetSha();
+        for (int index = 1; index <= 100; index++) {
+            flushScript();
+            final String newSha1 = loadScriptAndGetSha();
+            assertEquals(originSha1, newSha1);
+        }
+    }
+
+    @Test
+    @DisplayName("LuaScript를 빈으로 등록하면, 레디스에 등록된다.")
+    public void whenRegisterLuaScriptThenResultShouldExists() {
+        final List<Boolean> result = redisTemplate.execute((RedisCallback<List<Boolean>>) connection ->
+            connection.scriptingCommands().scriptExists(scriptSha)
+        );
+        Assertions.assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 루아 스크립트를 조회하면 false가 반환된다.")
+    public void whenNotRegisterLuaScriptThenResultShouldNull() {
+        final List<Boolean> invalidResult = redisTemplate.execute((RedisCallback<List<Boolean>>) connection ->
+            connection.scriptingCommands().scriptExists("INVALID_SCRIPT")
+        );
+        assertAll(
+            () -> Assertions.assertNotNull(invalidResult),
+            () -> Assertions.assertFalse(invalidResult.isEmpty()),
+            () -> Assertions.assertFalse(invalidResult.get(0))
+        );
+    }
 
     @Test
     @DisplayName("블랙 리스트로 등록 돼 있다면, 캐시가 존재하더라도 null을 반환한다.")
@@ -58,7 +115,7 @@ class UserCacheReadIntegrationTest extends DatabaseTestBase {
         userCacheWriteDao.save(userCache);
         final String blackListKey = String.format("user:blacklist:%d", userCache.getId());
         redisTemplate.opsForValue().set(blackListKey, compressAsByteArrayWithZstd(userCache, objectMapper));
-        assertNull(userCacheReadDao.findById(userCache.getId()));
+        assertNull(userCacheReadUseCase.findById(userCache.getId()));
     }
 
     @Test
@@ -73,7 +130,7 @@ class UserCacheReadIntegrationTest extends DatabaseTestBase {
         );
         userCacheWriteDao.save(userCache);
         assertAll(
-            () -> assertNotNull(userCacheReadDao.findById(userCache.getId())),
+            () -> Assertions.assertNotNull(userCacheReadUseCase.findById(userCache.getId())),
             () -> assertEquals(1L, userCache.getId()),
             () -> assertEquals("dailyge", userCache.getNickname()),
             () -> assertEquals("dailyge@gmail.com", userCache.getEmail()),
@@ -82,9 +139,16 @@ class UserCacheReadIntegrationTest extends DatabaseTestBase {
     }
 
     @Test
+    @DisplayName("등록된 루아 스크립트가 존재하지 않으면 CommonException이 발생한다.")
+    void whenScriptNotExistsThenCommonExceptionShouldBeHappen() {
+        flushScript();
+        assertThrows(CommonException.class, () -> userCacheReadUseCase.findById(1L));
+    }
+
+    @Test
     @DisplayName("캐시가 존재하지 않으면, null이 반환된다.")
     void whenNormalUserAndCacheNotExistsThenResultShouldBeNull() {
-        assertNull(userCacheReadDao.findById(Long.MAX_VALUE));
+        Assertions.assertNull(userCacheReadUseCase.findById(Long.MAX_VALUE));
     }
 
     @Test
@@ -99,11 +163,11 @@ class UserCacheReadIntegrationTest extends DatabaseTestBase {
         initCacheData(random);
 
         final long startTime = nanoTime();
-        for (int index = 1; index <= totalCount; index++) {
+        for (int index = 1; index <= 1; index++) {
             final long userId = random.nextLong();
             executorService.submit(() -> {
                 try {
-                    userCacheReadDao.findById(userId);
+                    userCacheReadUseCase.findById(userId);
                 } finally {
                     latch.countDown();
                 }
@@ -173,6 +237,19 @@ class UserCacheReadIntegrationTest extends DatabaseTestBase {
         }
         userCacheWriteDao.saveUserCacheBulk(userCaches);
         userCacheWriteDao.saveBlackListCacheBulk(blackList);
+    }
+
+    private void flushScript() {
+        redisTemplate.execute((RedisCallback<Void>) connection -> {
+            connection.scriptingCommands().scriptFlush();
+            return null;
+        });
+    }
+
+    private String loadScriptAndGetSha() {
+        return redisTemplate.execute((RedisCallback<String>) connection ->
+            connection.scriptingCommands().scriptLoad(script.getBytes())
+        );
     }
 
     private String getCacheKey(Long userId) {

--- a/storage/memory/src/main/java/project/dailyge/common/exception/RedisExceptionUtils.java
+++ b/storage/memory/src/main/java/project/dailyge/common/exception/RedisExceptionUtils.java
@@ -11,7 +11,11 @@ public final class RedisExceptionUtils {
         final Runnable runnable
     ) {
         if (message.contains("NOSCRIPT")) {
-            runnable.run();
+            reRegisterSha1(runnable);
         }
+    }
+
+    private static void reRegisterSha1(final Runnable runnable) {
+        runnable.run();
     }
 }

--- a/storage/memory/src/main/java/project/dailyge/common/exception/RedisExceptionUtils.java
+++ b/storage/memory/src/main/java/project/dailyge/common/exception/RedisExceptionUtils.java
@@ -1,0 +1,13 @@
+package project.dailyge.common.exception;
+
+public final class RedisExceptionUtils {
+
+    public static void resolveRedisSystemException(
+        final String message,
+        final Runnable runnable
+    ) {
+        if (message.contains("NOSCRIPT")) {
+            runnable.run();
+        }
+    }
+}

--- a/storage/memory/src/main/java/project/dailyge/common/exception/RedisExceptionUtils.java
+++ b/storage/memory/src/main/java/project/dailyge/common/exception/RedisExceptionUtils.java
@@ -2,6 +2,10 @@ package project.dailyge.common.exception;
 
 public final class RedisExceptionUtils {
 
+    private RedisExceptionUtils() {
+        throw new AssertionError("올바른 방식으로 생성자를 호출해주세요.");
+    }
+
     public static void resolveRedisSystemException(
         final String message,
         final Runnable runnable

--- a/storage/memory/src/test/java/project/dailyge/test/common/RedisExceptionUtilsUnitTest.java
+++ b/storage/memory/src/test/java/project/dailyge/test/common/RedisExceptionUtilsUnitTest.java
@@ -1,0 +1,35 @@
+package project.dailyge.test.common;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static project.dailyge.common.exception.RedisExceptionUtils.resolveRedisSystemException;
+
+@DisplayName("[UnitTest] RedisUtils 단위 테스트")
+class RedisExceptionUtilsUnitTest {
+
+    @Test
+    @DisplayName("에러 메시지가 NOSCRIPT를 포함하고 있다면 Runnable이 실행된다.")
+    void whenMessageContainsNoScriptThenRunnableIsExecuted() {
+        final String message = "NOSCRIPT";
+        final Runnable runnable = mock(Runnable.class);
+
+        resolveRedisSystemException(message, runnable);
+
+        then(runnable).should(times(1)).run();
+    }
+
+    @Test
+    @DisplayName("에러 메시지가 NOSCRIPT를 포함하고 있지 않다면 Runnable이 실행되지 않는다.")
+    void whenMessageDoesNotContainNoScriptThenRunnableIsNotExecuted() {
+        final String message = "Hello Error";
+        final Runnable runnable = mock(Runnable.class);
+
+        resolveRedisSystemException(message, runnable);
+
+        then(runnable).should(times(0)).run();
+    }
+}
+


### PR DESCRIPTION
## 📝 작업 내용

LuaScript를 매 번 레디스에 보내는 대신, 스프링 애플리케이션이 초기화될 때, 레디스에 EVALSHA 명령어로 등록한 후, 해시 값으로 이를 사용하도록 코드를 리팩토링했습니다.

- [x] EVALSHA로 해시 값으로 LuaScript 호출
- [x] 테스트 작성

<br/><br/>

## 📌 상세 내용

매 번 스크립트를 레디스에 같이 보내서 명령을 실행하는 것은 비효율적이라 판단해, 이를 애플리케이션이 로딩되는 시점에 레디스 메모리에 등록 후, 해시 값으로 사용하도록 코드를 수정했습니다. 그런데 코드를 수정하고 보니, 싱글 서버 레디스는 자동으로 스크립트가 캐싱되고, **`스크립트 자체가 작아`** 성능 개선이 거의 없었습니다. 

> 굳이 개선한 포인트를 찾자면 네트워크를 탈 때, **`데이터 부피가 작아지는`** 정도? 이것도 스크립트 자체가 짧아 어느정도 일지는 봐야겠네요.

<br/><br/><br/><br/>

오히려 **`레디스가 다운`** 됐을 경우, **`스크립트가 레디스 메모리에서 휘발`** 되기 때문에 이를 **`재등록`** 해야 하는 문제점만 발견한 것 같습니다. 스크립트가 존재하지 않을 경우, 아래와 같은 예외가 발생하거든요.

```shell
Caused by: io.lettuce.core.RedisNoScriptException: NOSCRIPT No matching script. Please use EVAL.
	at io.lettuce.core.internal.ExceptionFactory.createExecutionException(ExceptionFactory.java:136)
	at io.lettuce.core.internal.ExceptionFactory.createExecutionException(ExceptionFactory.java:116)
	at io.lettuce.core.protocol.AsyncCommand.completeResult(AsyncCommand.java:120)
	at io.lettuce.core.protocol.AsyncCommand.complete(AsyncCommand.java:111)
	at io.lettuce.core.protocol.CommandWrapper.complete(CommandWrapper.java:63)
	at io.lettuce.core.protocol.CommandHandler.complete(CommandHandler.java:745)
	at io.lettuce.core.protocol.CommandHandler.decode(CommandHandler.java:680)
```

<br/><br/><br/><br/>

우선 임시로 다시 한 번 재등록하는 코드를 추가했는데, 장애가 났을 경우, 중앙 서버에 알리고, 오케스트레이션 해주는게 더 나을 것 같아요. 혹은 이 커밋 자체를 Revert 하거나. 추석 끝나고 회의 때 한 번 이야기해보죠.

```java
@Repository
@RequiredArgsConstructor
public class UserCacheReadDao implements UserCacheReadRepository {

    private final RedisTemplate<String, byte[]> redisTemplate;
    private final String scriptSha;
    private final ObjectMapper objectMapper;

    @Override
    public UserCache findById(final Long userId) {
        try {
            final byte[] findCache = redisTemplate.execute((RedisCallback<byte[]>) connection ->
                connection.scriptingCommands()
                    .evalSha(scriptSha, VALUE, 2, getCacheKey(userId).getBytes(), getBlacklistKey(userId).getBytes()));
            if (findCache == null || findCache.length == 0) {
                return null;
            }
            return decompressAsObjWithZstd(findCache, UserCache.class, objectMapper);
        } catch (RedisSystemException ex) {
            // 재 등록
            resolveRedisSystemException(ex.getMessage(), getReRegisterScriptExecution());
            throw CommonException.from(ex.getMessage(), BAD_GATEWAY);
        } catch (RedisException ex) {
            throw CommonException.from(ex.getMessage(), BAD_GATEWAY);
        } catch (Exception ex) {
            throw CommonException.from(ex.getMessage(), INTERNAL_SERVER_ERROR);
        }
    }

    ......

        private Runnable getReRegisterScriptExecution() {
        try {
            return () -> redisTemplate.execute((RedisCallback<String>) connection ->
                connection.scriptingCommands().scriptLoad(USER_CACHE_SEARCH_LUA_SCRIPT.getBytes())
            );
        } catch (RedisException ex) {
            throw CommonException.from(ex.getMessage(), BAD_GATEWAY);
        } catch (Exception ex) {
            throw CommonException.from(ex.getMessage(), INTERNAL_SERVER_ERROR);
        }
    }

}
```

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-306)
