### PR TITLE
[DLG-316] 로그를 일시적으로 비활성화 한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
@@ -11,7 +11,6 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.MDC;
 import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
 import project.dailyge.app.common.annotation.ApplicationLayer;
 import project.dailyge.app.common.annotation.ExternalLayer;
 import project.dailyge.app.common.annotation.FacadeLayer;
@@ -31,7 +30,6 @@ import java.time.LocalDateTime;
 
 @Slf4j
 @Aspect
-// @Component
 @Profile("!test")
 @RequiredArgsConstructor
 public class LoggingAspect {

--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
@@ -31,7 +31,7 @@ import java.time.LocalDateTime;
 
 @Slf4j
 @Aspect
-@Component
+// @Component
 @Profile("!test")
 @RequiredArgsConstructor
 public class LoggingAspect {

--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/MdcFilter.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/MdcFilter.java
@@ -14,7 +14,6 @@ import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 import project.dailyge.app.common.auth.DailygeUser;
 import static project.dailyge.app.common.auth.DailygeUser.getDailygeUser;
 import static project.dailyge.app.common.utils.IpUtils.extractIpAddress;
@@ -38,7 +37,6 @@ import java.util.Base64;
 
 @Slf4j
 @Order(1)
-//@Component
 @Profile("!test")
 public class MdcFilter implements Filter {
 

--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/MdcFilter.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/MdcFilter.java
@@ -38,7 +38,7 @@ import java.util.Base64;
 
 @Slf4j
 @Order(1)
-@Component
+//@Component
 @Profile("!test")
 public class MdcFilter implements Filter {
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/application/service/EventValidator.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/application/service/EventValidator.java
@@ -1,0 +1,25 @@
+package project.dailyge.app.core.event.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import project.dailyge.app.core.event.exception.EventTypeException;
+import project.dailyge.app.core.event.persistence.LocalEventCache;
+
+import static project.dailyge.app.core.event.exception.EventCodeAndMessage.EVENT_NOT_FOUND;
+import static project.dailyge.app.core.event.exception.EventCodeAndMessage.INVALID_EVENT;
+
+@Component
+@RequiredArgsConstructor
+public class EventValidator {
+
+    private final LocalEventCache localEventCache;
+
+    public void validate(final Long eventId) {
+        if (!localEventCache.exists(eventId)) {
+            throw EventTypeException.from(EVENT_NOT_FOUND);
+        }
+        if (localEventCache.isExpired(eventId)) {
+            throw EventTypeException.from(INVALID_EVENT);
+        }
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/exception/EventCodeAndMessage.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/exception/EventCodeAndMessage.java
@@ -1,0 +1,34 @@
+package project.dailyge.app.core.event.exception;
+
+import lombok.Getter;
+import project.dailyge.app.codeandmessage.CodeAndMessage;
+
+@Getter
+public enum EventCodeAndMessage implements CodeAndMessage {
+
+    INVALID_EVENT(400, "유효하지 않은 이벤트입니다."),
+    EVENT_NOT_FOUND(404, "이벤트를 찾을 수 없습니다."),
+    EVENT_UN_RESOLVED_EXCEPTION(500, "이벤트 작업이 실패했습니다. 진행중인 작업을 확인해주세요.");
+
+    private final int code;
+    private final String message;
+
+    EventCodeAndMessage(
+        final int code,
+        final String message
+    ) {
+        this.code = code;
+        this.message = message;
+    }
+
+
+    @Override
+    public int code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/exception/EventTypeException.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/exception/EventTypeException.java
@@ -1,0 +1,60 @@
+package project.dailyge.app.core.event.exception;
+
+import lombok.Getter;
+import project.dailyge.app.common.exception.BusinessException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static project.dailyge.app.core.event.exception.EventCodeAndMessage.*;
+
+@Getter
+public sealed class EventTypeException extends BusinessException {
+
+    private static final Map<EventCodeAndMessage, EventTypeException> factory = new HashMap<>();
+
+    private EventTypeException(final EventCodeAndMessage codeAndMessage) {
+        super(codeAndMessage);
+    }
+
+    static {
+        factory.put(INVALID_EVENT, new InvalidEventException(INVALID_EVENT));
+        factory.put(EVENT_NOT_FOUND, new EventNotFoundException(EVENT_NOT_FOUND));
+        factory.put(EVENT_UN_RESOLVED_EXCEPTION, new EventUnResolvedException(EVENT_UN_RESOLVED_EXCEPTION));
+    }
+
+    public static EventTypeException from(final EventCodeAndMessage codeAndMessage) {
+        return getException(codeAndMessage);
+    }
+
+    private static EventTypeException getException(final EventCodeAndMessage codeAndMessage) {
+        final EventTypeException eventTypeException = factory.get(codeAndMessage);
+        if (eventTypeException != null) {
+            return eventTypeException;
+        }
+        return factory.get(EVENT_UN_RESOLVED_EXCEPTION);
+    }
+
+    @Override
+    protected void addDetailMessage(final String detailMessage) {
+        super.addDetailMessage(detailMessage);
+    }
+
+    private static final class EventNotFoundException extends EventTypeException {
+        private EventNotFoundException(final EventCodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+
+    private static final class InvalidEventException extends EventTypeException {
+        private InvalidEventException(final EventCodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+
+    private static final class EventUnResolvedException extends EventTypeException {
+        private EventUnResolvedException(final EventCodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/facade/EventFacade.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/facade/EventFacade.java
@@ -1,0 +1,34 @@
+package project.dailyge.app.core.event.facade;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import project.dailyge.app.common.annotation.FacadeLayer;
+import project.dailyge.app.common.auth.DailygeUser;
+import project.dailyge.app.core.coupon.application.CouponWriteUseCase;
+import project.dailyge.app.core.event.application.service.EventValidator;
+import project.dailyge.app.core.event.persistence.EventCache;
+import project.dailyge.app.core.event.persistence.LocalEventCache;
+
+import static java.time.LocalDateTime.now;
+
+@RequiredArgsConstructor
+@FacadeLayer(value = "EventFacade")
+public class EventFacade {
+
+    private final LocalEventCache localEventCache;
+    private final CouponWriteUseCase couponWriteUseCase;
+    private final EventValidator eventValidator;
+
+    @PostConstruct
+    public void init() {
+        localEventCache.save(new EventCache(1L, now(), now().plusMonths(1), 0L));
+    }
+
+    public void participateEvent(
+        final DailygeUser dailygeUser,
+        final Long eventId
+    ) {
+        eventValidator.validate(eventId);
+        couponWriteUseCase.saveApply(dailygeUser);
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/EventCache.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/EventCache.java
@@ -1,0 +1,65 @@
+package project.dailyge.app.core.event.persistence;
+
+import lombok.Getter;
+import project.dailyge.entity.event.EventJpaEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class EventCache {
+
+    private final Long id;
+    private final LocalDateTime startTime;
+    private final LocalDateTime endTime;
+    private final Long participants;
+
+    public EventCache(
+        final Long id,
+        final LocalDateTime startTime,
+        final LocalDateTime endTime,
+        final Long participants
+    ) {
+        this.id = id;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.participants = participants;
+    }
+
+    public static EventCache entityToCache(final EventJpaEntity eventJpaEntity) {
+        return new EventCache(
+            eventJpaEntity.getId(),
+            eventJpaEntity.getStartDate(),
+            eventJpaEntity.getEndDate(),
+            eventJpaEntity.getParticipants()
+        );
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof EventCache that)) {
+            return false;
+        }
+        if (getId() != null ? !getId().equals(that.getId()) : that.getId() != null) {
+            return false;
+        }
+        if (getStartTime() != null ? !getStartTime().equals(that.getStartTime()) : that.getStartTime() != null) {
+            return false;
+        }
+        if (getEndTime() != null ? !getEndTime().equals(that.getEndTime()) : that.getEndTime() != null) {
+            return false;
+        }
+        return getParticipants() != null ? getParticipants().equals(that.getParticipants()) : that.getParticipants() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getId() != null ? getId().hashCode() : 0;
+        result = 31 * result + (getStartTime() != null ? getStartTime().hashCode() : 0);
+        result = 31 * result + (getEndTime() != null ? getEndTime().hashCode() : 0);
+        result = 31 * result + (getParticipants() != null ? getParticipants().hashCode() : 0);
+        return result;
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/EventDocumentWriteDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/EventDocumentWriteDao.java
@@ -8,7 +8,7 @@ import project.dailyge.document.event.EventDocumentWriteRepository;
 
 @Repository
 @RequiredArgsConstructor
-public class EventWriteDao implements EventDocumentWriteRepository {
+public class EventDocumentWriteDao implements EventDocumentWriteRepository {
 
     private final MongoTemplate mongoTemplate;
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/EventEntityReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/EventEntityReadDao.java
@@ -1,0 +1,19 @@
+package project.dailyge.app.core.event.persistence;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import project.dailyge.entity.event.EventEntityReadRepository;
+import project.dailyge.entity.event.EventJpaEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class EventEntityReadDao implements EventEntityReadRepository {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public EventJpaEntity findById(final Long eventId) {
+        return entityManager.find(EventJpaEntity.class, eventId);
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/EventEntityWriteDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/EventEntityWriteDao.java
@@ -1,0 +1,22 @@
+package project.dailyge.app.core.event.persistence;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import project.dailyge.entity.event.EventEntityWriteRepository;
+import project.dailyge.entity.event.EventJpaEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class EventEntityWriteDao implements EventEntityWriteRepository {
+
+    private final EntityManager entityManager;
+
+    @Override
+    @Transactional
+    public Long save(final EventJpaEntity event) {
+        entityManager.persist(event);
+        return event.getId();
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/LocalEventCache.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/persistence/LocalEventCache.java
@@ -1,0 +1,29 @@
+package project.dailyge.app.core.event.persistence;
+
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@NoArgsConstructor
+public class LocalEventCache {
+
+    private final Map<Long, EventCache> cacheMap = new HashMap<>();
+
+    public void save(final EventCache eventCache) {
+        cacheMap.put(eventCache.getId(), eventCache);
+    }
+
+    public boolean exists(final Long eventId) {
+        return cacheMap.containsKey(eventId);
+    }
+
+    public boolean isExpired(final Long eventId) {
+        final EventCache eventCache = cacheMap.get(eventId);
+        final LocalDateTime now = LocalDateTime.now();
+        return !(now.isAfter(eventCache.getStartTime()) && now.isBefore(eventCache.getEndTime()));
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/event/presentation/EventCreateApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/event/presentation/EventCreateApi.java
@@ -1,0 +1,44 @@
+package project.dailyge.app.core.event.presentation;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import project.dailyge.app.common.annotation.PresentationLayer;
+import project.dailyge.app.common.auth.DailygeUser;
+import project.dailyge.app.common.auth.LoginUser;
+import project.dailyge.app.core.event.facade.EventFacade;
+
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
+import static org.springframework.http.HttpStatus.CREATED;
+import static project.dailyge.app.common.utils.CookieUtils.createResponseCookie;
+
+@PresentationLayer
+@RequestMapping("/api")
+public class EventCreateApi {
+
+    private final String env;
+    private final EventFacade eventFacade;
+
+    public EventCreateApi(
+        @Value("local") final String env,
+        final EventFacade eventFacade
+    ) {
+        this.env = env;
+        this.eventFacade = eventFacade;
+    }
+
+    @PostMapping(path = {"/events/{eventId}"})
+    public ResponseEntity<Void> createCouponEvent(
+        @LoginUser final DailygeUser dailygeUser,
+        @PathVariable(name = "eventId") final Long eventId
+    ) {
+        eventFacade.participateEvent(dailygeUser, eventId);
+        final String responseCookie = createResponseCookie("isParticipated", "true", "/", 7L * 60L * 60L, true, env);
+        return ResponseEntity
+            .status(CREATED)
+            .header(SET_COOKIE, responseCookie)
+            .build();
+    }
+}

--- a/dailyge-api/src/test/java/project/dailyge/app/test/event/documentationtest/CouponCreateDocumentationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/event/documentationtest/CouponCreateDocumentationTest.java
@@ -1,0 +1,41 @@
+package project.dailyge.app.test.event.documentationtest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import project.dailyge.app.common.DatabaseTestBase;
+import project.dailyge.app.core.event.persistence.EventCache;
+import project.dailyge.app.core.event.persistence.LocalEventCache;
+
+import static io.restassured.RestAssured.given;
+import static java.time.LocalDateTime.now;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@DisplayName("[DocumentationTest] 이벤트 참여 문서화 테스트")
+class CouponCreateDocumentationTest extends DatabaseTestBase {
+
+    @Autowired
+    private LocalEventCache localEventCache;
+
+    @BeforeEach
+    void setUp() {
+        localEventCache.save(new EventCache(1L, now().minusHours(1), now().plusMonths(1), 0L));
+    }
+
+    @Test
+    @DisplayName("[RestDocs] 쿠폰 이벤트에 참여하면 201 Created 응답을 받는다.")
+    void whenParticipateCouponEventThenResponseShouldBe_201_RestDocs() throws JsonProcessingException {
+        given(this.specification)
+            .relaxedHTTPSValidation()
+            .contentType(APPLICATION_JSON_VALUE)
+            .cookie(getAccessTokenCookie())
+            .when()
+            .post("/api/events/1")
+            .then()
+            .statusCode(201)
+            .log()
+            .all();
+    }
+}

--- a/dailyge-api/src/test/java/project/dailyge/app/test/event/unittest/EventValidatorUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/event/unittest/EventValidatorUnitTest.java
@@ -1,0 +1,75 @@
+package project.dailyge.app.test.event.unittest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import project.dailyge.app.core.event.application.service.EventValidator;
+import project.dailyge.app.core.event.exception.EventTypeException;
+import project.dailyge.app.core.event.persistence.EventCache;
+import project.dailyge.app.core.event.persistence.LocalEventCache;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static project.dailyge.app.core.event.exception.EventCodeAndMessage.EVENT_NOT_FOUND;
+import static project.dailyge.app.core.event.exception.EventCodeAndMessage.INVALID_EVENT;
+
+@DisplayName("[단위테스트] Event Validator 단위테스트")
+public class EventValidatorUnitTest {
+
+    private LocalEventCache localEventCache;
+    private EventValidator eventValidator;
+
+    @BeforeEach
+    void setUp() {
+        localEventCache = new LocalEventCache();
+        eventValidator = new EventValidator(localEventCache);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이벤트이면 EventTypeExcpetion을 던진다.")
+    void whenEventIdDoesNotExistsThenThrowEventTypeException() {
+        final Long notFoundEventId = Long.MAX_VALUE;
+        assertThrows(EventTypeException.from(EVENT_NOT_FOUND).getClass(), () -> eventValidator.validate(notFoundEventId));
+    }
+
+    @Test
+    @DisplayName("이미 지난 이벤트이면 EventTypeException을 던진다.")
+    void whenPastEventThenThrowEventTypeException() {
+        final EventCache pastEventCache = new EventCache(
+            2L,
+            LocalDateTime.now().minusHours(4),
+            LocalDateTime.now().minusHours(2),
+            0L
+        );
+        localEventCache.save(pastEventCache);
+        assertThrows(EventTypeException.from(INVALID_EVENT).getClass(), () -> eventValidator.validate(pastEventCache.getId()));
+    }
+
+    @Test
+    @DisplayName("시작하지 않은 이벤트이면 EventTypeException을 던진다.")
+    void whenEventDoesNotStartThenThrowEventTypeException() {
+        final EventCache futureEventCache = new EventCache(
+            3L,
+            LocalDateTime.now().plusHours(3),
+            LocalDateTime.now().plusHours(6),
+            0L
+        );
+        localEventCache.save(futureEventCache);
+        assertThrows(EventTypeException.from(INVALID_EVENT).getClass(), () -> eventValidator.validate(futureEventCache.getId()));
+    }
+
+    @Test
+    @DisplayName("진행중인 이벤트이면 EventTypeException을 던지지 않는다.")
+    void whenEventInProceedThenThrowEventTypeException() {
+        final EventCache eventCache = new EventCache(
+            1L,
+            LocalDateTime.now().minusHours(1),
+            LocalDateTime.now().plusHours(3),
+            0L
+        );
+        localEventCache.save(eventCache);
+        assertDoesNotThrow(() -> eventValidator.validate(eventCache.getId()));
+    }
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/event/EventEntityReadRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/event/EventEntityReadRepository.java
@@ -1,0 +1,5 @@
+package project.dailyge.entity.event;
+
+public interface EventEntityReadRepository {
+    EventJpaEntity findById(Long eventId);
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/event/EventEntityWriteRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/event/EventEntityWriteRepository.java
@@ -1,0 +1,5 @@
+package project.dailyge.entity.event;
+
+public interface EventEntityWriteRepository {
+    Long save(EventJpaEntity event);
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/event/EventJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/event/EventJpaEntity.java
@@ -1,17 +1,17 @@
 package project.dailyge.entity.event;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import project.dailyge.entity.BaseEntity;
 
 import java.time.LocalDateTime;
 
+import static lombok.AccessLevel.PROTECTED;
+
 @Getter
 @Entity(name = "events")
+@NoArgsConstructor(access = PROTECTED)
 public class EventJpaEntity extends BaseEntity {
 
     @Id
@@ -38,4 +38,22 @@ public class EventJpaEntity extends BaseEntity {
 
     @Column(name = "participants")
     private long participants;
+
+    public EventJpaEntity(
+        final String name,
+        final String description,
+        final LocalDateTime startDate,
+        final LocalDateTime endDate,
+        final int couponQuantity,
+        final boolean couponIssuance,
+        final long participants
+    ) {
+        this.name = name;
+        this.description = description;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.couponQuantity = couponQuantity;
+        this.couponIssuance = couponIssuance;
+        this.participants = participants;
+    }
 }

--- a/storage/rdb/src/main/java/project/dailyge/entity/event/EventWriteRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/event/EventWriteRepository.java
@@ -1,7 +1,0 @@
-package project.dailyge.entity.event;
-
-import project.dailyge.entity.common.Event;
-
-public interface EventWriteRepository {
-    void save(Event event);
-}


### PR DESCRIPTION
## 📝 작업 내용

AWS CloudWatch 비용을 모니터링 하던 중, 데이터 전송 용량이 128.83 GB 인 것을 보고 일시적으로 로그를 비활성화 했습니다.

- [x] 로그 설정 비활성화

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-316)
