### PR TITLE
[DLG-323] LogDocument _id를 별도로 생성한다.

### DIFF
--- a/.github/workflows/admin-api-static-analysis.yaml
+++ b/.github/workflows/admin-api-static-analysis.yaml
@@ -48,6 +48,9 @@ jobs:
             ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
             ${{ runner.os }}-gradle-
 
+      - name: Run Static Analysis
+        run: ./gradlew pmdMain pmdTest checkstyleMain checkstyleTest
+
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dailyge-api-ci.yaml
+++ b/.github/workflows/dailyge-api-ci.yaml
@@ -49,6 +49,9 @@ jobs:
             ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
             ${{ runner.os }}-gradle-
 
+      - name: Run Static Analysis
+        run: ./gradlew pmdMain pmdTest checkstyleMain checkstyleTest
+        
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/lint/dailyge-rule.xml
+++ b/config/lint/dailyge-rule.xml
@@ -40,6 +40,10 @@ The following rules in the Naver coding convention cannot be checked by this con
     </module>
 
     <module name="TreeWalker">
+        <module name="ParameterNumber">
+            <property name="max" value="15"/>
+        </module>
+
         <message key="name.invalidPattern"
                  value="[1-top-level-class] one.top.level.class=Top-level class {0} has to reside in its own source file."/>
 

--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/DailygeLogAppender.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/DailygeLogAppender.java
@@ -129,7 +129,7 @@ public class DailygeLogAppender extends AppenderBase<ILoggingEvent> {
     }
 
     @Scheduled(fixedDelay = 5_000)
-    private void scheduler() {
+    private synchronized void scheduler() {
         if (queue.isEmpty()) {
             return;
         }

--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
@@ -2,7 +2,6 @@ package project.dailyge.app.common.log;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import static java.lang.String.format;
-import static java.time.LocalDateTime.now;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +9,6 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.MDC;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import project.dailyge.app.common.annotation.ApplicationLayer;
 import project.dailyge.app.common.annotation.ExternalLayer;
@@ -24,6 +22,7 @@ import static project.dailyge.app.constant.LogConstant.METHOD;
 import static project.dailyge.app.constant.LogConstant.OUT_GOING;
 import static project.dailyge.app.constant.LogConstant.PATH;
 import static project.dailyge.app.constant.LogConstant.TRACE_ID;
+import static project.dailyge.app.constant.LogConstant.USER_ID;
 import static project.dailyge.app.utils.LogUtils.createLogMessage;
 
 import java.lang.annotation.Annotation;
@@ -32,14 +31,12 @@ import java.time.LocalDateTime;
 @Slf4j
 @Aspect
 @Component
-@Profile("!test")
 @RequiredArgsConstructor
 public class LoggingAspect {
 
     private static final String EMPTY_STRING = "";
     private static final String EMPTY_ARRAY = "[]";
     private static final String ANNOTATION_VALUE = "value";
-    private static final String DAILYGE_USER_KEY = "dailyge-user";
 
     private final ObjectMapper objectMapper;
 
@@ -83,10 +80,10 @@ public class LoggingAspect {
         final ProceedingJoinPoint joinPoint,
         final String layer
     ) throws Throwable {
-        final LocalDateTime startTime = now();
+        final LocalDateTime startTime = LocalDateTime.now();
         logStart(joinPoint, format("%s%s", layer, IN_COMING), startTime);
         final Object result = joinPoint.proceed();
-        final LocalDateTime endTime = now();
+        final LocalDateTime endTime = LocalDateTime.now();
         logEnd(joinPoint, format("%s%s", layer, OUT_GOING), startTime, endTime, result);
         return result;
     }
@@ -101,7 +98,7 @@ public class LoggingAspect {
             final String ip = MDC.get(IP);
             final String method = MDC.get(METHOD);
             final String path = MDC.get(PATH);
-            final String visitor = MDC.get(DAILYGE_USER_KEY);
+            final String visitor = MDC.get(USER_ID);
             final Object[] argsArray = joinPoint.getArgs();
             final String args = (argsArray != null) ? objectMapper.writeValueAsString(argsArray) : EMPTY_ARRAY;
             increaseOrder();
@@ -126,7 +123,7 @@ public class LoggingAspect {
             final String ip = MDC.get(IP);
             final String method = MDC.get(METHOD);
             final String path = MDC.get(PATH);
-            final String visitor = MDC.get(DAILYGE_USER_KEY);
+            final String visitor = MDC.get(USER_ID);
             final Object[] argsArray = joinPoint.getArgs();
             final String args = (argsArray != null) ? objectMapper.writeValueAsString(argsArray) : EMPTY_ARRAY;
             final long duration = MILLIS.between(startTime, endTime);

--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/MdcFilter.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/MdcFilter.java
@@ -28,6 +28,7 @@ import static project.dailyge.app.constant.LogConstant.USER_ID;
 import static project.dailyge.app.utils.LogUtils.createGuestLogMessage;
 import static project.dailyge.app.utils.LogUtils.createLogMessage;
 import static project.dailyge.document.common.UuidGenerator.createTimeBasedUUID;
+import static project.dailyge.entity.user.Role.GUEST;
 
 import java.io.IOException;
 import java.time.LocalDateTime;

--- a/storage/document/src/main/java/project/dailyge/document/common/UuidGenerator.java
+++ b/storage/document/src/main/java/project/dailyge/document/common/UuidGenerator.java
@@ -17,7 +17,6 @@ public final class UuidGenerator {
         long timeLow = leastSignificantBits >>> 32;
         long timeMid = (leastSignificantBits & 0xFFFF0000L) >>> 16;
         long timeHighAndVersion = (leastSignificantBits & 0x0FFF000000000000L) >>> 48;
-        long timestamp = (timeHighAndVersion << 48) | (timeMid << 32) | timeLow;
-        return timestamp;
+        return (timeHighAndVersion << 48) | (timeMid << 32) | timeLow;
     }
 }

--- a/storage/document/src/main/java/project/dailyge/document/log/OperationLogDocument.java
+++ b/storage/document/src/main/java/project/dailyge/document/log/OperationLogDocument.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
+import static project.dailyge.document.common.UuidGenerator.createTimeBasedUUID;
 
 import java.time.LocalDateTime;
 
@@ -14,17 +15,17 @@ public class OperationLogDocument {
     @Id
     @Field(name = "_id")
     private String id;
-    private String order;
-    private String layer;
-    private String path;
-    private String method;
-    private String traceId;
-    private String ip;
-    private String visitor;
+    private final String order;
+    private final String layer;
+    private final String path;
+    private final String method;
+    private final String traceId;
+    private final String ip;
+    private final String visitor;
     private final LocalDateTime time;
-    private String duration;
-    private Object context;
-    private String level;
+    private final String duration;
+    private final Object context;
+    private final String level;
 
     public OperationLogDocument(
         final String order,
@@ -39,7 +40,7 @@ public class OperationLogDocument {
         final Object context,
         final String level
     ) {
-        this.id = traceId;
+        this.id = createTimeBasedUUID();
         this.order = order;
         this.layer = layer;
         this.path = path;

--- a/storage/document/src/test/java/project/dailyge/document/log/OperationLogDocumentUnitTest.java
+++ b/storage/document/src/test/java/project/dailyge/document/log/OperationLogDocumentUnitTest.java
@@ -2,6 +2,7 @@ package project.dailyge.document.log;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +34,7 @@ class OperationLogDocumentUnitTest {
         assertAll(
             () -> assertNotNull(logDocument),
             () -> assertNotNull(logDocument.getId()),
-            () -> assertEquals(traceId, logDocument.getId()),
+            () -> assertNotEquals(traceId, logDocument.getId()),
             () -> assertEquals(order, logDocument.getOrder()),
             () -> assertEquals(layer, logDocument.getLayer()),
             () -> assertEquals(path, logDocument.getPath()),

--- a/support/src/main/java/project/dailyge/app/constant/LogConstant.java
+++ b/support/src/main/java/project/dailyge/app/constant/LogConstant.java
@@ -10,13 +10,13 @@ public interface LogConstant {
     String RESULT = "result";
     String TIME = "time";
 
-    String DEBUG = "DEBUG";
     String INFO = "INFO";
     String ERROR = "ERROR";
 
     String[] IP_HEADERS = {
         "X-Forwarded-For", "Proxy-Client-IP", "WL-Proxy-Client-IP", "HTTP_CLIENT_IP", "HTTP_X_FORWARDED_FOR"
     };
+    String USER_ID = "userId";
     String IP = "ip";
     String TRACE_ID = "traceId";
     String PATH = "path";


### PR DESCRIPTION
## 📝 작업 내용

LogDocument의 _id가 올바르지 않아 모든 로그가 저장되지 않는 문제가 있어 _id를 별도로 생성했습니다.

- [x] _id 를 별도로 생성
- [x] 사용하지 않는 변수 정리
- [x] 로그를 담을 때, synchronized 키워드 추가


<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-NUMBER)
