### PR TITLE
[DLG-324] User 정보 조회 시 ID 대신 쿠키의 JWT로 조회한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/presentation/UserReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/presentation/UserReadApi.java
@@ -21,13 +21,9 @@ public class UserReadApi {
 
     private final UserCacheReadUseCase userCacheReadUseCase;
 
-    @GetMapping(path = "/{userId}")
-    public ApiResponse<UserInfoResponse> findUserById(
-        @LoginUser final DailygeUser dailygeUser,
-        @PathVariable(value = "userId") final Long userId
-    ) {
-        dailygeUser.validateAuth(userId);
-        final UserCache findUser = userCacheReadUseCase.findById(userId);
+    @GetMapping
+    public ApiResponse<UserInfoResponse> findUserById(@LoginUser final DailygeUser dailygeUser) {
+        final UserCache findUser = userCacheReadUseCase.findById(dailygeUser.getUserId());
         final UserInfoResponse payload = new UserInfoResponse(findUser);
         return ApiResponse.from(OK, payload);
     }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserReadDocumentationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserReadDocumentationTest.java
@@ -9,7 +9,6 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
 import static project.dailyge.app.test.user.documentationtest.snippet.UserReadSnippet.createUserSearchFilter;
 import static project.dailyge.app.test.user.documentationtest.snippet.UserSnippet.USER_ACCESS_TOKEN_COOKIE_SNIPPET;
-import static project.dailyge.app.test.user.documentationtest.snippet.UserSnippet.USER_SEARCH_PATH_PARAMETER_SNIPPET;
 import static project.dailyge.app.test.user.documentationtest.snippet.UserSnippet.USER_SEARCH_RESPONSE_SNIPPET;
 import static project.dailyge.app.test.user.documentationtest.snippet.UserSnippet.createIdentifier;
 
@@ -22,13 +21,12 @@ class UserReadDocumentationTest extends DatabaseTestBase {
         given(this.specification)
             .filter(document(IDENTIFIER,
                 USER_ACCESS_TOKEN_COOKIE_SNIPPET,
-                USER_SEARCH_PATH_PARAMETER_SNIPPET,
                 USER_SEARCH_RESPONSE_SNIPPET
             ))
             .contentType(APPLICATION_JSON_VALUE)
             .cookie(getAccessTokenCookie())
             .when()
-            .get("/api/users/{userId}", newUser.getId())
+            .get("/api/users")
             .then()
             .statusCode(200)
             .log()
@@ -45,26 +43,9 @@ class UserReadDocumentationTest extends DatabaseTestBase {
             .contentType(APPLICATION_JSON_VALUE)
             .cookie(getAccessTokenCookie())
             .when()
-            .get("/api/users/{userId}", newUser.getId())
+            .get("/api/users")
             .then()
             .statusCode(200)
-            .log()
-            .all();
-    }
-
-    @Test
-    @DisplayName("[Swagger] 다른 사용자 정보를 조회하면, 403 UnAuthorized 응답을 받는다.")
-    void whenFindOtherUserThenStatusCodeShouldBe_403_UnAuthorized_Swagger() {
-        final RestDocumentationFilter filter = createUserSearchFilter(createIdentifier("UserSearch", 403));
-
-        given(this.specification)
-            .filter(filter)
-            .contentType(APPLICATION_JSON_VALUE)
-            .cookie(getAccessTokenCookie())
-            .when()
-            .get("/api/users/{userId}", Long.MAX_VALUE)
-            .then()
-            .statusCode(403)
             .log()
             .all();
     }
@@ -79,7 +60,7 @@ class UserReadDocumentationTest extends DatabaseTestBase {
             .contentType(APPLICATION_JSON_VALUE)
             .cookie("Access-Token", "ABCD")
             .when()
-            .get("/api/users/{userId}", Long.MAX_VALUE)
+            .get("/api/users")
             .then()
             .statusCode(403)
             .log()

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/snippet/UserReadSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/snippet/UserReadSnippet.java
@@ -10,7 +10,6 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
 public final class UserReadSnippet implements UserSnippet {
 
@@ -28,7 +27,6 @@ public final class UserReadSnippet implements UserSnippet {
         return document(
             identifier,
             ResourceSnippetParameters.builder()
-                .pathParameters(USER_SEARCH_PATH_DESCRIPTOR)
                 .responseFields(USER_SEARCH_RESPONSE_FIELD_DESCRIPTOR)
                 .tag(TAG)
                 .summary(USER_DETAIL_SEARCH_SUMMARY)
@@ -40,7 +38,6 @@ public final class UserReadSnippet implements UserSnippet {
             snippets -> {
                 List.of(
                     requestCookies(USER_ACCESS_TOKEN_COOKIE_DESCRIPTOR),
-                    pathParameters(USER_SEARCH_PATH_DESCRIPTOR),
                     responseFields(Arrays.stream(USER_SEARCH_RESPONSE_FIELD_DESCRIPTOR).toList()),
                     responseFields(Arrays.stream(RESPONSE_STATUS).toList())
                 );

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/snippet/UserSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/snippet/UserSnippet.java
@@ -30,10 +30,6 @@ public interface UserSnippet {
 
     RequestCookiesSnippet USER_ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(USER_ACCESS_TOKEN_COOKIE_DESCRIPTOR);
 
-    ParameterDescriptor[] USER_SEARCH_PATH_DESCRIPTOR = {
-        parameterWithName("userId").description("사용자 ID")
-    };
-
     FieldDescriptor[] USER_SEARCH_RESPONSE_FIELD_DESCRIPTOR = {
         fieldWithPath("data.userId").type(NUMBER).description("사용자 ID"),
         fieldWithPath("data.email").type(STRING).description("이메일"),
@@ -85,7 +81,6 @@ public interface UserSnippet {
     };
 
     // Search
-    PathParametersSnippet USER_SEARCH_PATH_PARAMETER_SNIPPET = pathParameters(USER_SEARCH_PATH_DESCRIPTOR);
     ResponseFieldsSnippet USER_SEARCH_RESPONSE_SNIPPET = responseFields(USER_SEARCH_RESPONSE_FIELD_DESCRIPTOR);
 
     // Update


### PR DESCRIPTION
## 📝 작업 내용

JWT 쿠키가 암호화 및 ReadOnly 쿠키로 변경됨에 따라 클라이언트에서는 UserId를 알 수 없기 때문에,
기본 User 정보 조회 시 PathVariable로 받던 ID를 대신 쿠키로 조회하도록 수정하였습니다.

- [X] 쿠키의 JWT로 User 정보 조회

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-324)
