### PR TITLE
[DLG-325] GCM 암호화 알고리즘을 사용하여 성능을 개선한다.

### DIFF
--- a/admin-api/src/main/java/project/dailyge/app/common/auth/TokenProvider.java
+++ b/admin-api/src/main/java/project/dailyge/app/common/auth/TokenProvider.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
 import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class TokenProvider {
 
     private static final String ID = "id";
     private static final int ARRAY_START_INDEX = 0;
-    private static final int IV_SIZE = 16;
+    private static final int IV_SIZE = 12;
     private static final SecureRandom secureRandom = new SecureRandom();
 
     private final JwtProperties jwtProperties;
@@ -137,10 +138,10 @@ public class TokenProvider {
         final byte[] cipherTarget
     ) {
         try {
-            final IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
+            final GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, iv);
             final SecretKeySpec secretKeySpec = secretKeyManager.getSecretKeySpec();
-            final Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-            cipher.init(operationMode, secretKeySpec, ivParameterSpec);
+            final Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(operationMode, secretKeySpec, gcmParameterSpec);
             return cipher.doFinal(cipherTarget);
         } catch (Exception ex) {
             throw CommonException.from(ex.getMessage(), INVALID_USER_TOKEN);

--- a/admin-api/src/test/java/project/dailyge/app/test/common/TokenProviderUnitTest.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/common/TokenProviderUnitTest.java
@@ -1,5 +1,6 @@
 package project.dailyge.app.test.common;
 
+import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -103,7 +104,7 @@ class TokenProviderUnitTest {
     void whenEncryptUserIdThenUserIdShouldBeEncrypted(final Long userId) {
         final String encryptedUserId = tokenProvider.encryptUserId(userId);
 
-        assertEquals(44, encryptedUserId.length());
+        assertDoesNotThrow(() -> Base64.getDecoder().decode(encryptedUserId));
     }
 
     @Test

--- a/dailyge-api/src/main/java/project/dailyge/app/common/auth/TokenProvider.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/auth/TokenProvider.java
@@ -9,7 +9,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SignatureException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import javax.crypto.Cipher;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,7 @@ public class TokenProvider {
     private static final String ID = "id";
     private static final SecureRandom secureRandom = new SecureRandom();
     private static final int ARRAY_START_INDEX = 0;
-    private static final int IV_SIZE = 16;
+    private static final int IV_SIZE = 12;
     private final JwtProperties jwtProperties;
     private final SecretKeyManager secretKeyManager;
 
@@ -139,10 +139,10 @@ public class TokenProvider {
         final byte[] cipherTarget
     ) {
         try {
-            final IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
+            final GCMParameterSpec gcmParameterSpec = new GCMParameterSpec(128, iv);
             final SecretKeySpec secretKeySpec = secretKeyManager.getSecretKeySpec();
-            final Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-            cipher.init(operationMode, secretKeySpec, ivParameterSpec);
+            final Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+            cipher.init(operationMode, secretKeySpec, gcmParameterSpec);
             return cipher.doFinal(cipherTarget);
         } catch (Exception ex) {
             throw CommonException.from(ex.getMessage(), INVALID_USER_TOKEN);

--- a/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
+++ b/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
@@ -25,8 +25,8 @@ CREATE TABLE IF NOT EXISTS tasks
 (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY    NOT NULL COMMENT '할 일 ID',
     user_id          BIGINT                               NOT NULL COMMENT '사용자 ID',
-    title            VARCHAR(255)                         NOT NULL COMMENT '제목',
-    content          VARCHAR(255)                         NOT NULL COMMENT '내용',
+    title            VARCHAR(150)                         NOT NULL COMMENT '제목',
+    content          VARCHAR(2500)                         NOT NULL COMMENT '내용',
     `month`          INT                                  NOT NULL COMMENT '월',
     `year`           INT                                  NOT NULL COMMENT '년',
     `date`           DATE                                 NOT NULL COMMENT '날짜',

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/TokenProviderUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/TokenProviderUnitTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -102,7 +103,7 @@ class TokenProviderUnitTest {
     void whenEncryptUserIdThenUserIdShouldBeEncrypted(final Long userId) {
         final String encryptedUserId = tokenProvider.encryptUserId(userId);
 
-        assertEquals(44, encryptedUserId.length());
+        assertDoesNotThrow(() -> Base64.getDecoder().decode(encryptedUserId));
     }
 
     @Test


### PR DESCRIPTION
## 📝 작업 내용

기존에 사용하고 있던 암호화 알고리즘인 `CBC`에 비해 좀 더 보안과 성능적으로 유리한 `GCM`으로 변경하였습니다.

자세한 사항은 해당 [Dicussions](https://github.com/dailyge/dailyge-server/discussions/181)에 공유해두겠습니다!

- [X] CBC 알고리즘을 GCM으로 변경
- [X] Test 코드 수정

<br/>

> 현재 정적 분석 실패는 [Config](https://github.com/dailyge/config-module/pull/54)가 merge 되면 정상적으로 성공할 것 입니다.

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-325)
