### PR TITLE
[DLG-328] 부하테스트를 위해 refresh token String으로 저장

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/external/oauth/TokenManager.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/external/oauth/TokenManager.java
@@ -1,42 +1,35 @@
 package project.dailyge.app.core.user.external.oauth;
 
 import io.lettuce.core.RedisException;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.BAD_GATEWAY;
-import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.INTERNAL_SERVER_ERROR;
 import project.dailyge.app.common.annotation.ExternalLayer;
 import project.dailyge.app.common.exception.CommonException;
-import static project.dailyge.common.configuration.CompressionHelper.compressStringAsByteArray;
-import static project.dailyge.common.configuration.CompressionHelper.decompressAsString;
 
 import java.util.function.Supplier;
+
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.BAD_GATEWAY;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.INTERNAL_SERVER_ERROR;
 
 @RequiredArgsConstructor
 @ExternalLayer(value = "TokenManager")
 public class TokenManager {
 
-    private final RedisTemplate<String, byte[]> redisTemplate;
+    private final RedisTemplate<String, String> redisTemplate;
 
     public void saveRefreshToken(
         final Long userId,
         final String refreshToken
     ) {
         executeRedisCommand(() -> {
-            final byte[] compressedRefreshToken = compressStringAsByteArray(refreshToken.getBytes(UTF_8));
-            redisTemplate.opsForValue().set(getKey(userId), compressedRefreshToken);
+            redisTemplate.opsForValue().set(getKey(userId), refreshToken);
             return null;
         });
     }
 
     public String getRefreshToken(final Long userId) {
         return executeRedisCommand(() -> {
-            final byte[] refreshToken = redisTemplate.opsForValue().get(getKey(userId));
-            if (refreshToken == null) {
-                return null;
-            }
-            return decompressAsString(refreshToken);
+            return redisTemplate.opsForValue().get(getKey(userId));
         });
     }
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/integrationtest/TokenManagerIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/integrationtest/TokenManagerIntegrationTest.java
@@ -1,22 +1,23 @@
 package project.dailyge.app.test.user.integrationtest;
 
 import io.lettuce.core.RedisConnectionException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.jupiter.api.Assertions;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
-import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.BAD_GATEWAY;
-import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.INTERNAL_SERVER_ERROR;
 import project.dailyge.app.common.DatabaseTestBase;
 import project.dailyge.app.common.exception.CommonException;
 import project.dailyge.app.core.user.external.oauth.TokenManager;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.BAD_GATEWAY;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.INTERNAL_SERVER_ERROR;
 
 @DisplayName("[IntegrationTest] TokenManager 통합 테스트")
 class TokenManagerIntegrationTest extends DatabaseTestBase {
@@ -30,7 +31,7 @@ class TokenManagerIntegrationTest extends DatabaseTestBase {
     private TokenManager tokenManager;
 
     private TokenManager mockTokenManager;
-    private RedisTemplate<String, byte[]> mockStringRedisTemplate;
+    private RedisTemplate<String, String> mockStringRedisTemplate;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
- redis에 refresh token 그대로 저장

## 📝 작업 내용

부하테스트 시 dev 환경에서 refresh token을 편하게 보기 위해서 Redis에 String을 저장하는 방식으로 바꿨습니다. 해당 PR은 부하테스트 종료 후 dev 브랜치에서 revert될 예정입니다.

- [X] redis에 refresh token String으로 저장한다.

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-328)
