### PR TITLE
[DLG-329] 부하테스트를 위해 secure 및 http only false 로 설정한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/common/utils/CookieUtils.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/utils/CookieUtils.java
@@ -23,8 +23,8 @@ public final class CookieUtils {
             final ResponseCookie cookie = ResponseCookie.from(name, value)
                 .domain(ROOT_DOMAIN)
                 .path(path)
-                .httpOnly(httpOnly)
-                .secure(true)
+                .httpOnly(false)
+                .secure(false)
                 .maxAge(maxAge)
                 .build();
             return cookie.toString();
@@ -45,8 +45,8 @@ public final class CookieUtils {
         final ResponseCookie clearCookie = ResponseCookie.from(name, null)
             .domain(ROOT_DOMAIN)
             .path("/")
-            .httpOnly(httpOnly)
-            .secure(true)
+            .httpOnly(false)
+            .secure(false)
             .maxAge(0)
             .build();
         return clearCookie.toString();
@@ -61,8 +61,8 @@ public final class CookieUtils {
         final Cookie cookie = new Cookie(name, value);
         cookie.setDomain(ROOT_DOMAIN);
         cookie.setPath(path);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+        cookie.setHttpOnly(false);
+        cookie.setSecure(false);
         cookie.setMaxAge(maxAge);
         return cookie;
     }
@@ -71,8 +71,8 @@ public final class CookieUtils {
         final Cookie cookie = new Cookie(name, null);
         cookie.setDomain(ROOT_DOMAIN);
         cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
+        cookie.setHttpOnly(false);
+        cookie.setSecure(false);
         cookie.setMaxAge(0);
         return cookie;
     }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/CookieUtilsUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/CookieUtilsUnitTest.java
@@ -1,14 +1,15 @@
 package project.dailyge.app.test.common;
 
 import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import project.dailyge.app.common.utils.CookieUtils;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import project.dailyge.app.common.utils.CookieUtils;
 import static project.dailyge.app.common.utils.CookieUtils.createCookie;
 import static project.dailyge.app.common.utils.CookieUtils.createResponseCookie;
 
@@ -29,8 +30,8 @@ class CookieUtilsUnitTest {
             () -> assertEquals(0, cookie.getMaxAge()),
             () -> assertEquals(".dailyge.com", cookie.getDomain()),
             () -> assertEquals("/", cookie.getPath()),
-            () -> assertTrue(cookie.getSecure()),
-            () -> assertTrue(cookie.isHttpOnly()),
+            () -> assertFalse(cookie.getSecure()),
+            () -> assertFalse(cookie.isHttpOnly()),
             () -> assertNull(cookie.getValue())
         );
     }
@@ -44,8 +45,8 @@ class CookieUtilsUnitTest {
             () -> assertTrue(cookieString.contains("Max-Age=0")),
             () -> assertTrue(cookieString.contains("Domain=.dailyge.com")),
             () -> assertTrue(cookieString.contains("Path=/")),
-            () -> assertTrue(cookieString.contains("Secure")),
-            () -> assertTrue(cookieString.contains("HttpOnly"))
+            () -> assertFalse(cookieString.contains("Secure")),
+            () -> assertFalse(cookieString.contains("HttpOnly"))
         );
     }
 
@@ -74,8 +75,8 @@ class CookieUtilsUnitTest {
             () -> assertTrue(cookieString.contains("Max-Age=86400")),
             () -> assertTrue(cookieString.contains("Domain=.dailyge.com")),
             () -> assertTrue(cookieString.contains("Path=" + COOKIE_PATH)),
-            () -> assertTrue(cookieString.contains("Secure")),
-            () -> assertTrue(cookieString.contains("HttpOnly"))
+            () -> assertFalse(cookieString.contains("Secure")),
+            () -> assertFalse(cookieString.contains("HttpOnly"))
         );
     }
 
@@ -89,8 +90,8 @@ class CookieUtilsUnitTest {
             () -> assertEquals((int) MAX_AGE, cookie.getMaxAge()),
             () -> assertEquals(".dailyge.com", cookie.getDomain()),
             () -> assertEquals(COOKIE_PATH, cookie.getPath()),
-            () -> assertTrue(cookie.getSecure()),
-            () -> assertTrue(cookie.isHttpOnly())
+            () -> assertFalse(cookie.getSecure()),
+            () -> assertFalse(cookie.isHttpOnly())
         );
     }
 }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/DailygeTokenUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/DailygeTokenUnitTest.java
@@ -1,12 +1,13 @@
 package project.dailyge.app.test.common;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import project.dailyge.app.common.auth.DailygeToken;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import project.dailyge.app.common.auth.DailygeToken;
 
 @DisplayName("[UnitTest] DailygeToken 단위 테스트")
 class DailygeTokenUnitTest {
@@ -27,8 +28,8 @@ class DailygeTokenUnitTest {
             () -> assertTrue(accessTokenCookie.contains("Access-Token=accessTokenValue")),
             () -> assertTrue(accessTokenCookie.contains("Max-Age=1800")),
             () -> assertTrue(accessTokenCookie.contains("Path=/")),
-            () -> assertTrue(accessTokenCookie.contains("Secure")),
-            () -> assertTrue(accessTokenCookie.contains("HttpOnly")),
+            () -> assertFalse(accessTokenCookie.contains("Secure")),
+            () -> assertFalse(accessTokenCookie.contains("HttpOnly")),
             () -> assertTrue(accessTokenCookie.contains("Domain=.dailyge.com"))
         );
     }
@@ -42,8 +43,8 @@ class DailygeTokenUnitTest {
             () -> assertTrue(refreshTokenCookie.contains("Refresh-Token=refreshTokenValue")),
             () -> assertTrue(refreshTokenCookie.contains("Max-Age=2592000")),
             () -> assertTrue(refreshTokenCookie.contains("Path=/")),
-            () -> assertTrue(refreshTokenCookie.contains("Secure")),
-            () -> assertTrue(refreshTokenCookie.contains("HttpOnly")),
+            () -> assertFalse(refreshTokenCookie.contains("Secure")),
+            () -> assertFalse(refreshTokenCookie.contains("HttpOnly")),
             () -> assertTrue(refreshTokenCookie.contains("Domain=.dailyge.com"))
         );
     }


### PR DESCRIPTION
## 📝 작업 내용

부하테스트를 위해 secure, http only를 false로 설정합니다. dev 운영환경에서만 사용하고 부하테스트 끝난 뒤에 revert할 예정입니다.

- [X] secure 및 http only false 로 설정한다.

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-329)
