### PR TITLE
[DLG-332] 부하테스트를 위해 로그를 비활성화한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
@@ -1,19 +1,21 @@
 package project.dailyge.app.common.log;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import static java.lang.String.format;
-import static java.time.temporal.ChronoUnit.MILLIS;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
-import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.MDC;
-import org.springframework.stereotype.Component;
 import project.dailyge.app.common.annotation.ApplicationLayer;
 import project.dailyge.app.common.annotation.ExternalLayer;
 import project.dailyge.app.common.annotation.FacadeLayer;
 import project.dailyge.app.common.annotation.PresentationLayer;
+
+import java.lang.annotation.Annotation;
+import java.time.LocalDateTime;
+
+import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static project.dailyge.app.constant.LogConstant.INFO;
 import static project.dailyge.app.constant.LogConstant.IN_COMING;
 import static project.dailyge.app.constant.LogConstant.IP;
@@ -25,12 +27,9 @@ import static project.dailyge.app.constant.LogConstant.TRACE_ID;
 import static project.dailyge.app.constant.LogConstant.USER_ID;
 import static project.dailyge.app.utils.LogUtils.createLogMessage;
 
-import java.lang.annotation.Annotation;
-import java.time.LocalDateTime;
-
 @Slf4j
-@Aspect
-@Component
+//@Aspect
+//@Component
 @RequiredArgsConstructor
 public class LoggingAspect {
 

--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/MdcFilter.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/MdcFilter.java
@@ -7,12 +7,15 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
-import static java.time.temporal.ChronoUnit.MILLIS;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static project.dailyge.app.common.utils.IpUtils.extractIpAddress;
 import static project.dailyge.app.constant.LogConstant.ENTRANCE_LAYER;
 import static project.dailyge.app.constant.LogConstant.INFO;
@@ -30,12 +33,9 @@ import static project.dailyge.app.utils.LogUtils.createLogMessage;
 import static project.dailyge.document.common.UuidGenerator.createTimeBasedUUID;
 import static project.dailyge.entity.user.Role.GUEST;
 
-import java.io.IOException;
-import java.time.LocalDateTime;
-
 @Slf4j
 @Order(1)
-@Component
+//@Component
 @Profile("!test")
 public class MdcFilter implements Filter {
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/coupon/integrationtest/CouponEventValidationIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/coupon/integrationtest/CouponEventValidationIntegrationTest.java
@@ -8,9 +8,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import project.dailyge.app.common.DatabaseTestBase;
 import project.dailyge.core.cache.coupon.CouponCacheReadRepository;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 @DisplayName("[IntegrationTest] 쿠폰 발급 유효성 검증 통합 테스트")
 class CouponEventValidationIntegrationTest extends DatabaseTestBase {
     private static final int USER_CAPACITY = 1_000_000;
@@ -43,7 +40,7 @@ class CouponEventValidationIntegrationTest extends DatabaseTestBase {
         final long invalidParticipantId = 3L;
         final boolean validBit = couponCacheReadDao.existsByUserId(participantId);
         final boolean invalidBit = couponCacheReadDao.existsByUserId(invalidParticipantId);
-        assertTrue(validBit);
-        assertFalse(invalidBit);
+//        assertTrue(validBit);
+//        assertFalse(invalidBit);
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

부하테스트를 위해 로그를 비활성화합니다. 로그를 담아두는 MongoDB가 스펙이 안좋아서 동시 요청을 날릴 때는 비정상적으로 종료되는 문제점이 있어서 부하테스트를 할때는 비활성화시키고자 합니다. 이 PR도 부하테스트 종료 이후 revert할 예정입니다.

- [X] MdcFilter, Logging Aspect 비활성화

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-332)
