### PR TITLE
[DLG-333] 부하테스트를 위해 고정 스케줄러 추가한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/coupon/application/service/SchedulerService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/coupon/application/service/SchedulerService.java
@@ -1,0 +1,18 @@
+package project.dailyge.app.core.coupon.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import project.dailyge.app.common.annotation.ApplicationLayer;
+import project.dailyge.core.cache.coupon.CouponCacheWriteUseCase;
+
+@ApplicationLayer(value = "SchedulerService")
+@RequiredArgsConstructor
+class SchedulerService {
+
+    private final CouponCacheWriteUseCase couponCacheWriteUseCase;
+
+    @Scheduled(fixedRate = 5000)
+    public void schedule() {
+        couponCacheWriteUseCase.saveBulks();
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

로드밸런서 쪽에서 스케줄러 시작/중지 API를 제어하다보니, 특정 서버에서 스케줄러가 제어되는지를 세세하게 보기가 힘들었습니다. 이러한 이유로 dev 환경에서 부하테스트 시 고정 스케줄러를 임시로 사용하고자 합니다. 이 PR은 부하테스트 이후 revert될 예정입니다. 부하테스트 시 스크립트랑 Ngrinder에 원인이 있어서 이 PR은 close 하겠습니다.

- [X] 고정 스케줄러 추가
<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-333)
