### PR TITLE
[DLG-344] 기념일 등록 API를 개발한다.

### DIFF
--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -25,8 +25,8 @@ CREATE TABLE IF NOT EXISTS tasks
 (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY    NOT NULL COMMENT '할 일 ID',
     user_id          BIGINT                               NOT NULL COMMENT '사용자 ID',
-    title            VARCHAR(255)                         NOT NULL COMMENT '제목',
-    content          VARCHAR(255)                         NOT NULL COMMENT '내용',
+    title            VARCHAR(150)                         NOT NULL COMMENT '제목',
+    content          VARCHAR(2500)                        NOT NULL COMMENT '내용',
     `month`          INT                                  NOT NULL COMMENT '월',
     `year`           INT                                  NOT NULL COMMENT '년',
     `date`           DATE                                 NOT NULL COMMENT '날짜',
@@ -119,3 +119,33 @@ CREATE TABLE IF NOT EXISTS monthly_goals
     last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) engine = 'InnoDB' COMMENT '월간 목표';
+
+DROP TABLE IF EXISTS anniversaries;
+CREATE TABLE IF NOT EXISTS anniversaries
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '기념일 ID',
+    name             VARCHAR(50)                       NOT NULL COMMENT '이름',
+    date             TIMESTAMP                         NOT NULL COMMENT '기념일 날짜',
+    remind           BIT                               NOT NULL COMMENT '알림 여부',
+    emoji_id         BIGINT                            NULL COMMENT '이모지 ID',
+    user_id          BIGINT                            NOT NULL COMMENT '사용자 ID',
+    created_at       TIMESTAMP                         NOT NULL COMMENT '생성일',
+    created_by       BIGINT                            NULL COMMENT '생성한 사람',
+    last_modified_at TIMESTAMP                         NOT NULL COMMENT '최종 수정일',
+    last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
+    deleted          BIT                               NOT NULL COMMENT '삭제 유무'
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT '기념일';
+
+DROP TABLE IF EXISTS emojis;
+CREATE TABLE IF NOT EXISTS emojis
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '이모티콘 ID',
+    emoji            VARCHAR(255)                      NOT NULL COMMENT '이모티콘',
+    created_at       TIMESTAMP                         NOT NULL COMMENT '생성일',
+    created_by       BIGINT                            NULL COMMENT '생성한 사람',
+    last_modified_at TIMESTAMP                         NOT NULL COMMENT '최종 수정일',
+    last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
+    deleted          BIT                               NOT NULL COMMENT '삭제 유무'
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT '이모티콘';

--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -136,7 +136,7 @@ CREATE TABLE IF NOT EXISTS anniversaries
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT '기념일',
-  COLLATE utf8mb4_0900_ai_ci;;
+  COLLATE utf8mb4_general_ci;;
 
 DROP TABLE IF EXISTS emojis;
 CREATE TABLE IF NOT EXISTS emojis
@@ -150,4 +150,4 @@ CREATE TABLE IF NOT EXISTS emojis
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT '이모티콘',
-  COLLATE utf8mb4_0900_ai_ci;
+  COLLATE utf8mb4_general_ci;

--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -135,7 +135,8 @@ CREATE TABLE IF NOT EXISTS anniversaries
     last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4 COMMENT '기념일';
+  DEFAULT CHARSET = utf8mb4 COMMENT '기념일',
+  COLLATE utf8mb4_0900_ai_ci;;
 
 DROP TABLE IF EXISTS emojis;
 CREATE TABLE IF NOT EXISTS emojis
@@ -148,4 +149,5 @@ CREATE TABLE IF NOT EXISTS emojis
     last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4 COMMENT '이모티콘';
+  DEFAULT CHARSET = utf8mb4 COMMENT '이모티콘',
+  COLLATE utf8mb4_0900_ai_ci;

--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS anniversaries
     name             VARCHAR(50)                       NOT NULL COMMENT '이름',
     date             TIMESTAMP                         NOT NULL COMMENT '기념일 날짜',
     remind           BIT                               NOT NULL COMMENT '알림 여부',
-    emoji_id         BIGINT                            NULL COMMENT '이모지 ID',
+    emoji_id         BIGINT                            NULL COMMENT '이모티콘 ID',
     user_id          BIGINT                            NOT NULL COMMENT '사용자 ID',
     created_at       TIMESTAMP                         NOT NULL COMMENT '생성일',
     created_by       BIGINT                            NULL COMMENT '생성한 사람',

--- a/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/log/LoggingAspect.java
@@ -9,6 +9,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.slf4j.MDC;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import project.dailyge.app.common.annotation.ApplicationLayer;
 import project.dailyge.app.common.annotation.ExternalLayer;
@@ -31,6 +32,7 @@ import java.time.LocalDateTime;
 @Slf4j
 @Aspect
 @Component
+@Profile("!test")
 @RequiredArgsConstructor
 public class LoggingAspect {
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/AnniversaryReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/AnniversaryReadService.java
@@ -1,0 +1,7 @@
+package project.dailyge.app.core.anniversary.application;
+
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+
+public interface AnniversaryReadService {
+    AnniversaryJpaEntity findById(Long anniversaryId);
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/AnniversaryWriteService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/AnniversaryWriteService.java
@@ -1,0 +1,8 @@
+package project.dailyge.app.core.anniversary.application;
+
+import project.dailyge.app.common.auth.DailygeUser;
+import project.dailyge.app.core.anniversary.application.command.AnniversaryCreateCommand;
+
+public interface AnniversaryWriteService {
+    Long save(DailygeUser dailygeUser, AnniversaryCreateCommand command);
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/command/AnniversaryCreateCommand.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/command/AnniversaryCreateCommand.java
@@ -1,0 +1,23 @@
+package project.dailyge.app.core.anniversary.application.command;
+
+import project.dailyge.app.common.auth.DailygeUser;
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+
+import java.time.LocalDateTime;
+
+public record AnniversaryCreateCommand(
+    String name,
+    LocalDateTime date,
+    boolean remind,
+    Long emojiId
+) {
+
+    public AnniversaryJpaEntity toEntity(final DailygeUser dailygeUser) {
+        return new AnniversaryJpaEntity(name, date, remind, emojiId, dailygeUser.getUserId());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{\"name\":\"%s\", \"date\":\"%s\", \"remind\":%b, \"emojiId\":%d}", name, date, remind, emojiId);
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/usecase/AnniversaryReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/usecase/AnniversaryReadUseCase.java
@@ -1,0 +1,22 @@
+package project.dailyge.app.core.anniversary.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import project.dailyge.app.common.annotation.ApplicationLayer;
+import project.dailyge.app.core.anniversary.application.AnniversaryReadService;
+import static project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage.ANNIVERSARY_NOT_FOUND;
+import project.dailyge.app.core.anniversary.exception.AnniversaryTypeException;
+import project.dailyge.entity.anniversary.AnniversaryEntityReadRepository;
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+
+@RequiredArgsConstructor
+@ApplicationLayer(value = "AnniversaryReadUseCase")
+class AnniversaryReadUseCase implements AnniversaryReadService {
+
+    private final AnniversaryEntityReadRepository anniversaryEntityReadRepository;
+
+    @Override
+    public AnniversaryJpaEntity findById(final Long anniversaryId) {
+        return anniversaryEntityReadRepository.findById(anniversaryId)
+            .orElseThrow(() -> AnniversaryTypeException.from(ANNIVERSARY_NOT_FOUND));
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/usecase/AnniversaryWriteUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/usecase/AnniversaryWriteUseCase.java
@@ -1,4 +1,4 @@
-package project.dailyge.app.core.anniversary.application.useecase;
+package project.dailyge.app.core.anniversary.application.usecase;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/useecase/AnniversaryWriteUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/application/useecase/AnniversaryWriteUseCase.java
@@ -1,0 +1,34 @@
+package project.dailyge.app.core.anniversary.application.useecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import project.dailyge.app.common.annotation.ApplicationLayer;
+import project.dailyge.app.common.auth.DailygeUser;
+import project.dailyge.app.core.anniversary.application.AnniversaryWriteService;
+import project.dailyge.app.core.anniversary.application.command.AnniversaryCreateCommand;
+import static project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage.DUPLICATED_ANNIVERSARY;
+import project.dailyge.app.core.anniversary.exception.AnniversaryTypeException;
+import project.dailyge.entity.anniversary.AnniversaryEntityReadRepository;
+import project.dailyge.entity.anniversary.AnniversaryEntityWriteRepository;
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+
+@RequiredArgsConstructor
+@ApplicationLayer(value = "AnniversaryWriteUseCase")
+class AnniversaryWriteUseCase implements AnniversaryWriteService {
+
+    private final AnniversaryEntityReadRepository anniversaryEntityReadRepository;
+    private final AnniversaryEntityWriteRepository anniversaryEntityWriteRepository;
+
+    @Override
+    @Transactional
+    public Long save(
+        final DailygeUser dailygeUser,
+        final AnniversaryCreateCommand command
+    ) {
+        if (anniversaryEntityReadRepository.exists(command.name(), command.date())) {
+            throw AnniversaryTypeException.from(DUPLICATED_ANNIVERSARY);
+        }
+        final AnniversaryJpaEntity newAnniversary = command.toEntity(dailygeUser);
+        return anniversaryEntityWriteRepository.save(newAnniversary);
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/exception/AnniversaryCodeAndMessage.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/exception/AnniversaryCodeAndMessage.java
@@ -5,8 +5,8 @@ import project.dailyge.app.codeandmessage.CodeAndMessage;
 
 @Getter
 public enum AnniversaryCodeAndMessage implements CodeAndMessage {
-    DUPLICATED_ANNIVERSARY(400, "동일한 기념일이 존재합니다."),
     ANNIVERSARY_NOT_FOUND(404, "기념일이 존재하지 않습니다."),
+    DUPLICATED_ANNIVERSARY(409, "동일한 기념일이 존재합니다."),
     ANNIVERSARY_UN_RESOLVED_EXCEPTION(500, "작업이 실패했습니다. 진행중인 작업을 확인해주세요.");
 
     private final int code;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/exception/AnniversaryCodeAndMessage.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/exception/AnniversaryCodeAndMessage.java
@@ -1,0 +1,32 @@
+package project.dailyge.app.core.anniversary.exception;
+
+import lombok.Getter;
+import project.dailyge.app.codeandmessage.CodeAndMessage;
+
+@Getter
+public enum AnniversaryCodeAndMessage implements CodeAndMessage {
+    DUPLICATED_ANNIVERSARY(400, "동일한 기념일이 존재합니다."),
+    ANNIVERSARY_NOT_FOUND(404, "기념일이 존재하지 않습니다."),
+    ANNIVERSARY_UN_RESOLVED_EXCEPTION(500, "작업이 실패했습니다. 진행중인 작업을 확인해주세요.");
+
+    private final int code;
+    private final String message;
+
+    AnniversaryCodeAndMessage(
+        final int code,
+        final String message
+    ) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/exception/AnniversaryTypeException.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/exception/AnniversaryTypeException.java
@@ -6,7 +6,6 @@ import project.dailyge.app.common.exception.BusinessException;
 import static project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage.ANNIVERSARY_NOT_FOUND;
 import static project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage.ANNIVERSARY_UN_RESOLVED_EXCEPTION;
 import static project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage.DUPLICATED_ANNIVERSARY;
-import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TASK_UN_RESOLVED_EXCEPTION;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +45,7 @@ public sealed class AnniversaryTypeException extends BusinessException {
         if (findAnniversaryTypeException != null) {
             return findAnniversaryTypeException;
         }
-        return factory.get(TASK_UN_RESOLVED_EXCEPTION);
+        return factory.get(ANNIVERSARY_UN_RESOLVED_EXCEPTION);
     }
 
     @Override

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/exception/AnniversaryTypeException.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/exception/AnniversaryTypeException.java
@@ -1,0 +1,74 @@
+package project.dailyge.app.core.anniversary.exception;
+
+import lombok.Getter;
+import project.dailyge.app.codeandmessage.CodeAndMessage;
+import project.dailyge.app.common.exception.BusinessException;
+import static project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage.ANNIVERSARY_NOT_FOUND;
+import static project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage.ANNIVERSARY_UN_RESOLVED_EXCEPTION;
+import static project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage.DUPLICATED_ANNIVERSARY;
+import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TASK_UN_RESOLVED_EXCEPTION;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public sealed class AnniversaryTypeException extends BusinessException {
+
+    private static final Map<CodeAndMessage, AnniversaryTypeException> factory = new HashMap<>();
+
+    private AnniversaryTypeException(final CodeAndMessage codeAndMessage) {
+        super(codeAndMessage);
+    }
+
+    static {
+        factory.put(DUPLICATED_ANNIVERSARY, new AnniversaryDuplicatedException(DUPLICATED_ANNIVERSARY));
+        factory.put(ANNIVERSARY_NOT_FOUND, new AnniversaryNotFoundException(ANNIVERSARY_NOT_FOUND));
+        factory.put(ANNIVERSARY_UN_RESOLVED_EXCEPTION, new AnniversaryUnResolvedException(ANNIVERSARY_UN_RESOLVED_EXCEPTION));
+    }
+
+    public static AnniversaryTypeException from(final AnniversaryCodeAndMessage codeAndMessage) {
+        return getException(codeAndMessage);
+    }
+
+    public static AnniversaryTypeException from(
+        final String detailMessage,
+        final AnniversaryCodeAndMessage codeAndMessage
+    ) {
+        final AnniversaryTypeException anniversaryTypeException = getException(codeAndMessage);
+        if (detailMessage != null) {
+            anniversaryTypeException.addDetailMessage(detailMessage);
+        }
+        return anniversaryTypeException;
+    }
+
+    private static AnniversaryTypeException getException(final CodeAndMessage codeAndMessage) {
+        final AnniversaryTypeException findAnniversaryTypeException = factory.get(codeAndMessage);
+        if (findAnniversaryTypeException != null) {
+            return findAnniversaryTypeException;
+        }
+        return factory.get(TASK_UN_RESOLVED_EXCEPTION);
+    }
+
+    @Override
+    protected void addDetailMessage(final String detailMessage) {
+        super.addDetailMessage(detailMessage);
+    }
+
+    private static final class AnniversaryDuplicatedException extends AnniversaryTypeException {
+        private AnniversaryDuplicatedException(final CodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+
+    private static final class AnniversaryNotFoundException extends AnniversaryTypeException {
+        private AnniversaryNotFoundException(final CodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+
+    private static final class AnniversaryUnResolvedException extends AnniversaryTypeException {
+        private AnniversaryUnResolvedException(final CodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/facade/AnniversaryFacade.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/facade/AnniversaryFacade.java
@@ -1,0 +1,26 @@
+package project.dailyge.app.core.anniversary.facade;
+
+import lombok.RequiredArgsConstructor;
+import project.dailyge.app.common.annotation.FacadeLayer;
+import project.dailyge.app.common.auth.DailygeUser;
+import project.dailyge.app.core.anniversary.application.AnniversaryWriteService;
+import project.dailyge.app.core.anniversary.application.command.AnniversaryCreateCommand;
+import project.dailyge.app.core.emoji.application.EmojiReadService;
+
+@RequiredArgsConstructor
+@FacadeLayer(value = "AnniversaryFacade")
+public class AnniversaryFacade {
+
+    private final EmojiReadService emojiReadService;
+    private final AnniversaryWriteService anniversaryWriteService;
+
+    public Long save(
+        final DailygeUser dailygeUser,
+        final AnniversaryCreateCommand command
+    ) {
+        if (command.emojiId() != null) {
+            emojiReadService.validateExists(command.emojiId());
+        }
+        return anniversaryWriteService.save(dailygeUser, command);
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/persistence/AnniversaryEntityReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/persistence/AnniversaryEntityReadDao.java
@@ -1,0 +1,43 @@
+package project.dailyge.app.core.anniversary.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import project.dailyge.entity.anniversary.AnniversaryEntityReadRepository;
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+import static project.dailyge.entity.anniversary.QAnniversaryJpaEntity.anniversaryJpaEntity;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+class AnniversaryEntityReadDao implements AnniversaryEntityReadRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<AnniversaryJpaEntity> findById(final Long anniversaryId) {
+        return Optional.ofNullable(
+            queryFactory.selectFrom(anniversaryJpaEntity)
+                .where(anniversaryJpaEntity.id.eq(anniversaryId)
+                    .and(anniversaryJpaEntity.deleted.eq(false))
+                )
+                .fetchOne()
+        );
+    }
+
+    @Override
+    public boolean exists(
+        final String name,
+        final LocalDateTime date
+    ) {
+        final Integer findAnniversary = queryFactory.selectOne()
+            .from(anniversaryJpaEntity)
+            .where(anniversaryJpaEntity.name.eq(name)
+                .and(anniversaryJpaEntity.date.eq(date))
+                .and(anniversaryJpaEntity.deleted.eq(false))
+            ).fetchFirst();
+        return findAnniversary != null;
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/persistence/AnniversaryEntityWriteDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/persistence/AnniversaryEntityWriteDao.java
@@ -1,0 +1,20 @@
+package project.dailyge.app.core.anniversary.persistence;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+import project.dailyge.entity.anniversary.AnniversaryEntityWriteRepository;
+
+@Repository
+@RequiredArgsConstructor
+class AnniversaryEntityWriteDao implements AnniversaryEntityWriteRepository {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public Long save(final AnniversaryJpaEntity anniversary) {
+        entityManager.persist(anniversary);
+        return anniversary.getId();
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/AnniversaryCreateApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/AnniversaryCreateApi.java
@@ -1,0 +1,33 @@
+package project.dailyge.app.core.anniversary.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.CREATED;
+import project.dailyge.app.common.annotation.PresentationLayer;
+import project.dailyge.app.common.auth.DailygeUser;
+import project.dailyge.app.common.auth.LoginUser;
+import project.dailyge.app.common.response.ApiResponse;
+import project.dailyge.app.core.anniversary.facade.AnniversaryFacade;
+import project.dailyge.app.core.anniversary.presentation.request.AnniversaryCreateRequest;
+import project.dailyge.app.core.anniversary.presentation.response.AnniversaryCreateResponse;
+
+@RequiredArgsConstructor
+@RequestMapping(path = "/api/anniversaries")
+@PresentationLayer(value = "AnniversaryCreateApi")
+public class AnniversaryCreateApi {
+
+    private final AnniversaryFacade anniversaryFacade;
+
+    @PostMapping
+    public ApiResponse<AnniversaryCreateResponse> createAnniversary(
+        @LoginUser DailygeUser dailygeUser,
+        @Valid @RequestBody AnniversaryCreateRequest request
+    ) {
+        final Long newAnniversaryId = anniversaryFacade.save(dailygeUser, request.toCommand());
+        final AnniversaryCreateResponse payload = new AnniversaryCreateResponse(newAnniversaryId);
+        return ApiResponse.from(CREATED, payload);
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/request/AnniversaryCreateRequest.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/request/AnniversaryCreateRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import project.dailyge.app.core.anniversary.application.command.AnniversaryCreateCommand;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 public class AnniversaryCreateRequest {
@@ -14,7 +14,7 @@ public class AnniversaryCreateRequest {
     private String name;
 
     @NotNull
-    private LocalDateTime date;
+    private LocalDate date;
 
     private boolean remind;
     private Long emojiId;
@@ -24,7 +24,7 @@ public class AnniversaryCreateRequest {
 
     public AnniversaryCreateRequest(
         final String name,
-        final LocalDateTime date,
+        final LocalDate date,
         final boolean remind,
         final Long emojiId
     ) {
@@ -35,7 +35,7 @@ public class AnniversaryCreateRequest {
     }
 
     public AnniversaryCreateCommand toCommand() {
-        return new AnniversaryCreateCommand(name, date, remind, emojiId);
+        return new AnniversaryCreateCommand(name, date.atTime(0, 0), remind, emojiId);
     }
 
     @Override

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/request/AnniversaryCreateRequest.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/request/AnniversaryCreateRequest.java
@@ -1,0 +1,50 @@
+package project.dailyge.app.core.anniversary.presentation.request;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import project.dailyge.app.core.anniversary.application.command.AnniversaryCreateCommand;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class AnniversaryCreateRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    @Column(name = "date")
+    private LocalDateTime date;
+
+    private boolean remind;
+    private Long emojiId;
+
+    private AnniversaryCreateRequest() {
+    }
+
+    public AnniversaryCreateRequest(
+        final String name,
+        final LocalDateTime date,
+        final boolean remind,
+        final Long emojiId
+    ) {
+        this.name = name;
+        this.date = date;
+        this.remind = remind;
+        this.emojiId = emojiId;
+    }
+
+    public AnniversaryCreateCommand toCommand() {
+        return new AnniversaryCreateCommand(name, date, remind, emojiId);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "{\"name\":\"%s\", \"date\":\"%s\", \"remind\":%b, \"emojiId\":%d}",
+            name, date.toString(), remind, emojiId != null ? emojiId : null
+        );
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/request/AnniversaryCreateRequest.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/request/AnniversaryCreateRequest.java
@@ -1,6 +1,5 @@
 package project.dailyge.app.core.anniversary.presentation.request;
 
-import jakarta.persistence.Column;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -15,7 +14,6 @@ public class AnniversaryCreateRequest {
     private String name;
 
     @NotNull
-    @Column(name = "date")
     private LocalDateTime date;
 
     private boolean remind;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/response/AnniversaryCreateResponse.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/anniversary/presentation/response/AnniversaryCreateResponse.java
@@ -1,0 +1,21 @@
+package project.dailyge.app.core.anniversary.presentation.response;
+
+import lombok.Getter;
+
+@Getter
+public class AnniversaryCreateResponse {
+
+    private Long anniversaryId;
+
+    private AnniversaryCreateResponse() {
+    }
+
+    public AnniversaryCreateResponse(final Long anniversaryId) {
+        this.anniversaryId = anniversaryId;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{\"anniversaryId\":%d}", anniversaryId);
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/web/ServerWarmUpRunner.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/web/ServerWarmUpRunner.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.stereotype.Component;
@@ -21,6 +22,7 @@ import java.util.stream.IntStream;
 
 @Slf4j
 @Component
+@Profile({"dev"})
 @RequiredArgsConstructor
 public class ServerWarmUpRunner implements ApplicationRunner {
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/EmojiReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/EmojiReadService.java
@@ -1,0 +1,5 @@
+package project.dailyge.app.core.emoji.application;
+
+public interface EmojiReadService {
+    void validateExists(Long emojiId);
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/EmojiWriteService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/EmojiWriteService.java
@@ -1,0 +1,4 @@
+package project.dailyge.app.core.emoji.application;
+
+public interface EmojiWriteService {
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/EmojiWriteService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/EmojiWriteService.java
@@ -1,4 +1,7 @@
 package project.dailyge.app.core.emoji.application;
 
+import project.dailyge.entity.emoji.EmojiJpaEntity;
+
 public interface EmojiWriteService {
+    Long save(EmojiJpaEntity emoji);
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/usecase/EmojiReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/usecase/EmojiReadUseCase.java
@@ -1,0 +1,21 @@
+package project.dailyge.app.core.emoji.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import project.dailyge.app.common.annotation.ApplicationLayer;
+import project.dailyge.app.core.emoji.application.EmojiReadService;
+import static project.dailyge.app.core.emoji.exception.EmojiCodeAndMessage.EMOJI_NOT_FOUND;
+import project.dailyge.app.core.emoji.exception.EmojiTypeException;
+import project.dailyge.entity.emoji.EmojiEntityReadRepository;
+
+@RequiredArgsConstructor
+@ApplicationLayer(value = "EmojiReadUseCase")
+class EmojiReadUseCase implements EmojiReadService {
+
+    private final EmojiEntityReadRepository emojiEntityReadRepository;
+
+    @Override
+    public void validateExists(final Long emojiId) {
+        emojiEntityReadRepository.findById(emojiId)
+            .orElseThrow(() -> EmojiTypeException.from(EMOJI_NOT_FOUND));
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/usecase/EmojiWriteUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/usecase/EmojiWriteUseCase.java
@@ -1,0 +1,11 @@
+package project.dailyge.app.core.emoji.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import project.dailyge.app.common.annotation.ApplicationLayer;
+
+@RequiredArgsConstructor
+@ApplicationLayer(value = "EmojiWriteUseCase")
+class EmojiWriteUseCase {
+
+
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/usecase/EmojiWriteUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/application/usecase/EmojiWriteUseCase.java
@@ -1,11 +1,21 @@
 package project.dailyge.app.core.emoji.application.usecase;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import project.dailyge.app.common.annotation.ApplicationLayer;
+import project.dailyge.app.core.emoji.application.EmojiWriteService;
+import project.dailyge.entity.emoji.EmojiEntityWriteRepository;
+import project.dailyge.entity.emoji.EmojiJpaEntity;
 
 @RequiredArgsConstructor
 @ApplicationLayer(value = "EmojiWriteUseCase")
-class EmojiWriteUseCase {
+class EmojiWriteUseCase implements EmojiWriteService {
 
+    private final EmojiEntityWriteRepository emojiEntityWriteRepository;
 
+    @Override
+    @Transactional
+    public Long save(final EmojiJpaEntity emoji) {
+        return emojiEntityWriteRepository.save(emoji);
+    }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/exception/EmojiCodeAndMessage.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/exception/EmojiCodeAndMessage.java
@@ -1,0 +1,31 @@
+package project.dailyge.app.core.emoji.exception;
+
+import lombok.Getter;
+import project.dailyge.app.codeandmessage.CodeAndMessage;
+
+@Getter
+public enum EmojiCodeAndMessage implements CodeAndMessage {
+    EMOJI_NOT_FOUND(404, "이모티콘이 존재하지 않습니다."),
+    EMOJI_UN_RESOLVED_EXCEPTION(500, "작업이 실패했습니다. 진행중인 작업을 확인해주세요.");
+
+    private final int code;
+    private final String message;
+
+    EmojiCodeAndMessage(
+        final int code,
+        final String message
+    ) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public int code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/exception/EmojiTypeException.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/exception/EmojiTypeException.java
@@ -5,7 +5,6 @@ import project.dailyge.app.codeandmessage.CodeAndMessage;
 import project.dailyge.app.common.exception.BusinessException;
 import static project.dailyge.app.core.emoji.exception.EmojiCodeAndMessage.EMOJI_NOT_FOUND;
 import static project.dailyge.app.core.emoji.exception.EmojiCodeAndMessage.EMOJI_UN_RESOLVED_EXCEPTION;
-import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TASK_UN_RESOLVED_EXCEPTION;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +43,7 @@ public sealed class EmojiTypeException extends BusinessException {
         if (findEmojiTypeException != null) {
             return findEmojiTypeException;
         }
-        return factory.get(TASK_UN_RESOLVED_EXCEPTION);
+        return factory.get(EMOJI_UN_RESOLVED_EXCEPTION);
     }
 
     @Override

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/exception/EmojiTypeException.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/exception/EmojiTypeException.java
@@ -1,0 +1,66 @@
+package project.dailyge.app.core.emoji.exception;
+
+import lombok.Getter;
+import project.dailyge.app.codeandmessage.CodeAndMessage;
+import project.dailyge.app.common.exception.BusinessException;
+import static project.dailyge.app.core.emoji.exception.EmojiCodeAndMessage.EMOJI_NOT_FOUND;
+import static project.dailyge.app.core.emoji.exception.EmojiCodeAndMessage.EMOJI_UN_RESOLVED_EXCEPTION;
+import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TASK_UN_RESOLVED_EXCEPTION;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public sealed class EmojiTypeException extends BusinessException {
+
+    private static final Map<CodeAndMessage, EmojiTypeException> factory = new HashMap<>();
+
+    private EmojiTypeException(final CodeAndMessage codeAndMessage) {
+        super(codeAndMessage);
+    }
+
+    static {
+        factory.put(EMOJI_NOT_FOUND, new EmojiNotFoundException(EMOJI_NOT_FOUND));
+        factory.put(EMOJI_UN_RESOLVED_EXCEPTION, new EmojiUnResolvedException(EMOJI_UN_RESOLVED_EXCEPTION));
+    }
+
+    public static EmojiTypeException from(final EmojiCodeAndMessage codeAndMessage) {
+        return getException(codeAndMessage);
+    }
+
+    public static EmojiTypeException from(
+        final String detailMessage,
+        final EmojiCodeAndMessage codeAndMessage
+    ) {
+        final EmojiTypeException emojiTypeException = getException(codeAndMessage);
+        if (detailMessage != null) {
+            emojiTypeException.addDetailMessage(detailMessage);
+        }
+        return emojiTypeException;
+    }
+
+    private static EmojiTypeException getException(final CodeAndMessage codeAndMessage) {
+        final EmojiTypeException findEmojiTypeException = factory.get(codeAndMessage);
+        if (findEmojiTypeException != null) {
+            return findEmojiTypeException;
+        }
+        return factory.get(TASK_UN_RESOLVED_EXCEPTION);
+    }
+
+    @Override
+    protected void addDetailMessage(final String detailMessage) {
+        super.addDetailMessage(detailMessage);
+    }
+
+    private static final class EmojiNotFoundException extends EmojiTypeException {
+        private EmojiNotFoundException(final CodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+
+    private static final class EmojiUnResolvedException extends EmojiTypeException {
+        private EmojiUnResolvedException(final CodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/persistence/EmojiReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/persistence/EmojiReadDao.java
@@ -1,0 +1,28 @@
+package project.dailyge.app.core.emoji.persistence;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import project.dailyge.entity.emoji.EmojiEntityReadRepository;
+import project.dailyge.entity.emoji.EmojiJpaEntity;
+import static project.dailyge.entity.emoji.QEmojiJpaEntity.emojiJpaEntity;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+class EmojiReadDao implements EmojiEntityReadRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<EmojiJpaEntity> findById(final Long emojiId) {
+        return Optional.ofNullable(
+            queryFactory.selectFrom(emojiJpaEntity)
+                .where(emojiJpaEntity.id.eq(emojiId)
+                    .and(emojiJpaEntity.deleted.eq(false))
+                )
+                .fetchOne()
+        );
+    }
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/emoji/persistence/EmojiWriteDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/emoji/persistence/EmojiWriteDao.java
@@ -1,0 +1,20 @@
+package project.dailyge.app.core.emoji.persistence;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import project.dailyge.entity.emoji.EmojiEntityWriteRepository;
+import project.dailyge.entity.emoji.EmojiJpaEntity;
+
+@Repository
+@RequiredArgsConstructor
+class EmojiWriteDao implements EmojiEntityWriteRepository {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public Long save(final EmojiJpaEntity emoji) {
+        entityManager.persist(emoji);
+        return emoji.getId();
+    }
+}

--- a/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
+++ b/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
@@ -136,7 +136,7 @@ CREATE TABLE IF NOT EXISTS anniversaries
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT '기념일',
-  COLLATE utf8mb4_0900_ai_ci;;
+  COLLATE utf8mb4_general_ci;;
 
 DROP TABLE IF EXISTS emojis;
 CREATE TABLE IF NOT EXISTS emojis
@@ -150,4 +150,4 @@ CREATE TABLE IF NOT EXISTS emojis
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT '이모티콘',
-  COLLATE utf8mb4_0900_ai_ci;
+  COLLATE utf8mb4_general_ci;

--- a/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
+++ b/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
@@ -135,7 +135,8 @@ CREATE TABLE IF NOT EXISTS anniversaries
     last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4 COMMENT '기념일';
+  DEFAULT CHARSET = utf8mb4 COMMENT '기념일',
+  COLLATE utf8mb4_0900_ai_ci;;
 
 DROP TABLE IF EXISTS emojis;
 CREATE TABLE IF NOT EXISTS emojis
@@ -148,4 +149,5 @@ CREATE TABLE IF NOT EXISTS emojis
     last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4 COMMENT '이모티콘';
+  DEFAULT CHARSET = utf8mb4 COMMENT '이모티콘',
+  COLLATE utf8mb4_0900_ai_ci;

--- a/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
+++ b/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS anniversaries
     name             VARCHAR(50)                       NOT NULL COMMENT '이름',
     date             TIMESTAMP                         NOT NULL COMMENT '기념일 날짜',
     remind           BIT                               NOT NULL COMMENT '알림 여부',
-    emoji_id         BIGINT                            NULL COMMENT '이모지 ID',
+    emoji_id         BIGINT                            NULL COMMENT '이모티콘 ID',
     user_id          BIGINT                            NOT NULL COMMENT '사용자 ID',
     created_at       TIMESTAMP                         NOT NULL COMMENT '생성일',
     created_by       BIGINT                            NULL COMMENT '생성한 사람',

--- a/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
+++ b/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS tasks
     id               BIGINT AUTO_INCREMENT PRIMARY KEY    NOT NULL COMMENT '할 일 ID',
     user_id          BIGINT                               NOT NULL COMMENT '사용자 ID',
     title            VARCHAR(150)                         NOT NULL COMMENT '제목',
-    content          VARCHAR(2500)                         NOT NULL COMMENT '내용',
+    content          VARCHAR(2500)                        NOT NULL COMMENT '내용',
     `month`          INT                                  NOT NULL COMMENT '월',
     `year`           INT                                  NOT NULL COMMENT '년',
     `date`           DATE                                 NOT NULL COMMENT '날짜',
@@ -119,3 +119,33 @@ CREATE TABLE IF NOT EXISTS monthly_goals
     last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) engine = 'InnoDB' COMMENT '월간 목표';
+
+DROP TABLE IF EXISTS anniversaries;
+CREATE TABLE IF NOT EXISTS anniversaries
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '기념일 ID',
+    name             VARCHAR(50)                       NOT NULL COMMENT '이름',
+    date             TIMESTAMP                         NOT NULL COMMENT '기념일 날짜',
+    remind           BIT                               NOT NULL COMMENT '알림 여부',
+    emoji_id         BIGINT                            NULL COMMENT '이모지 ID',
+    user_id          BIGINT                            NOT NULL COMMENT '사용자 ID',
+    created_at       TIMESTAMP                         NOT NULL COMMENT '생성일',
+    created_by       BIGINT                            NULL COMMENT '생성한 사람',
+    last_modified_at TIMESTAMP                         NOT NULL COMMENT '최종 수정일',
+    last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
+    deleted          BIT                               NOT NULL COMMENT '삭제 유무'
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT '기념일';
+
+DROP TABLE IF EXISTS emojis;
+CREATE TABLE IF NOT EXISTS emojis
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '이모티콘 ID',
+    emoji            VARCHAR(255)                      NOT NULL COMMENT '이모티콘',
+    created_at       TIMESTAMP                         NOT NULL COMMENT '생성일',
+    created_by       BIGINT                            NULL COMMENT '생성한 사람',
+    last_modified_at TIMESTAMP                         NOT NULL COMMENT '최종 수정일',
+    last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
+    deleted          BIT                               NOT NULL COMMENT '삭제 유무'
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT '이모티콘';

--- a/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/documentationtest/AnniversaryCreateDocumentationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/documentationtest/AnniversaryCreateDocumentationTest.java
@@ -1,0 +1,79 @@
+package project.dailyge.app.test.anniversary.documentationtest;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import static io.restassured.RestAssured.given;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.restdocs.restassured.RestAssuredRestDocumentation.document;
+import org.springframework.restdocs.restassured.RestDocumentationFilter;
+import project.dailyge.app.common.DatabaseTestBase;
+import project.dailyge.app.core.anniversary.presentation.request.AnniversaryCreateRequest;
+import static project.dailyge.app.test.anniversary.documentationtest.snippet.AnniversaryCreateSnippet.createAnniversaryFilter;
+import static project.dailyge.app.test.anniversary.documentationtest.snippet.AnniversarySnippet.ACCESS_TOKEN_COOKIE_SNIPPET;
+import static project.dailyge.app.test.anniversary.documentationtest.snippet.AnniversarySnippet.ANNIVERSARY_CREATE_REQUEST_SNIPPET;
+import static project.dailyge.app.test.anniversary.documentationtest.snippet.AnniversarySnippet.ANNIVERSARY_CREATE_RESPONSE_SNIPPET;
+import static project.dailyge.app.test.anniversary.documentationtest.snippet.AnniversarySnippet.createIdentifier;
+
+import java.time.LocalDate;
+
+@DisplayName("[DocumentationTest] 기념일 저장 문서화 테스트")
+class AnniversaryCreateDocumentationTest extends DatabaseTestBase {
+
+    @Test
+    @DisplayName("[RestDocs] 기념일을 생성하면 201 응답 코드를 받는다.")
+    void whenCreateAnniversaryThenStatusCodeShouldBe_201_RestDocs() throws JsonProcessingException {
+        final LocalDate date = LocalDate.now();
+        final AnniversaryCreateRequest request = new AnniversaryCreateRequest("부모님 결혼 기념일", date, false, null);
+        given(this.specification)
+            .relaxedHTTPSValidation()
+            .filter(document(IDENTIFIER,
+                ACCESS_TOKEN_COOKIE_SNIPPET,
+                ANNIVERSARY_CREATE_REQUEST_SNIPPET,
+                ANNIVERSARY_CREATE_RESPONSE_SNIPPET
+            ))
+            .contentType(APPLICATION_JSON_VALUE)
+            .cookie(getAccessTokenCookie())
+            .body(objectMapper.writeValueAsString(request))
+            .when()
+            .post("/api/anniversaries")
+            .then()
+            .statusCode(201);
+    }
+
+    @Test
+    @DisplayName("[Swagger] 기념일을 생성하면 201 응답 코드를 받는다.")
+    void whenCreateAnniversaryThenStatusCodeShouldBe_201_Swagger() throws JsonProcessingException {
+        final LocalDate date = LocalDate.now();
+        final AnniversaryCreateRequest request = new AnniversaryCreateRequest("부모님 결혼 기념일", date, false, null);
+        final RestDocumentationFilter filter = createAnniversaryFilter(createIdentifier("AnniversaryCreate", 201));
+        given(this.specification)
+            .relaxedHTTPSValidation()
+            .filter(filter)
+            .contentType(APPLICATION_JSON_VALUE)
+            .cookie(getAccessTokenCookie())
+            .body(objectMapper.writeValueAsString(request))
+            .when()
+            .post("/api/anniversaries")
+            .then()
+            .statusCode(201);
+    }
+
+    @Test
+    @DisplayName("[Swagger] 올바르지 않은 파라미터를 넘기면 400 Bad Request 응답을 받는다.")
+    void whenCreateAnniversaryWithInvalidParameterThenStatusCodeShouldBe_400_Swagger() throws JsonProcessingException {
+        final LocalDate date = LocalDate.now();
+        final AnniversaryCreateRequest request = new AnniversaryCreateRequest(null, date, false, null);
+        final RestDocumentationFilter filter = createAnniversaryFilter(createIdentifier("AnniversaryCreate", 400));
+        given(this.specification)
+            .relaxedHTTPSValidation()
+            .filter(filter)
+            .contentType(APPLICATION_JSON_VALUE)
+            .cookie(getAccessTokenCookie())
+            .body(objectMapper.writeValueAsString(request))
+            .when()
+            .post("/api/anniversaries")
+            .then()
+            .statusCode(400);
+    }
+}

--- a/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/documentationtest/snippet/AnniversaryCreateSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/documentationtest/snippet/AnniversaryCreateSnippet.java
@@ -1,0 +1,49 @@
+package project.dailyge.app.test.anniversary.documentationtest.snippet;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import org.springframework.restdocs.restassured.RestDocumentationFilter;
+import static project.dailyge.app.test.task.documentationtest.snippet.TaskSnippet.ERROR_RESPONSE;
+
+import java.util.Arrays;
+import java.util.List;
+
+public final class AnniversaryCreateSnippet implements AnniversarySnippet {
+
+    private static final String SUMMARY = "Anniversary 등록 API";
+    private static final String DESCRIPTION = "Anniversary를 등록합니다.";
+
+    private AnniversaryCreateSnippet() {
+        throw new AssertionError("올바른 방식으로 생성자를 호출해주세요.");
+    }
+
+    public static RestDocumentationFilter createAnniversaryFilter(final String identifier) {
+        return document(
+            identifier,
+            ResourceSnippetParameters.builder()
+                .requestFields(ANNIVERSARY_CREATE_REQUEST_FIELDS)
+                .responseFields(ANNIVERSARY_CREATE_RESPONSE)
+                .tag(TAG)
+                .summary(SUMMARY)
+                .privateResource(false)
+                .deprecated(false)
+                .description(DESCRIPTION),
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            snippets -> {
+                List.of(
+                    requestCookies(TOKEN_COOKIE_DESCRIPTORS),
+                    requestFields(Arrays.stream(ANNIVERSARY_CREATE_REQUEST_FIELDS).toList()),
+                    responseFields(Arrays.stream(ANNIVERSARY_CREATE_RESPONSE).toList()),
+                    responseFields(Arrays.stream(ERROR_RESPONSE).toList())
+                );
+            }
+        );
+    }
+}

--- a/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/documentationtest/snippet/AnniversarySnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/documentationtest/snippet/AnniversarySnippet.java
@@ -31,7 +31,7 @@ public interface AnniversarySnippet {
         fieldWithPath("date").description("날짜")
             .attributes(getAttribute(AnniversaryCreateRequest.class, "date")),
         fieldWithPath("remind").description("리마인드"),
-        fieldWithPath("emojiId").description("리마인드")
+        fieldWithPath("emojiId").description("이모티콘 ID")
             .attributes(getAttribute(AnniversaryCreateRequest.class, "emojiId")),
     };
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/documentationtest/snippet/AnniversarySnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/documentationtest/snippet/AnniversarySnippet.java
@@ -1,0 +1,55 @@
+package project.dailyge.app.test.anniversary.documentationtest.snippet;
+
+import static javax.xml.xpath.XPathEvaluationResult.XPathResultType.NUMBER;
+import static javax.xml.xpath.XPathEvaluationResult.XPathResultType.STRING;
+import org.springframework.restdocs.cookies.CookieDescriptor;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import org.springframework.restdocs.cookies.RequestCookiesSnippet;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import org.springframework.restdocs.payload.RequestFieldsSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import static project.dailyge.app.common.SnippetUtils.getAttribute;
+import project.dailyge.app.core.anniversary.presentation.request.AnniversaryCreateRequest;
+
+public interface AnniversarySnippet {
+
+    String TAG = "Anniversary";
+    String identifier = "{class_name}/{method_name}/";
+
+    CookieDescriptor[] TOKEN_COOKIE_DESCRIPTORS = {
+        cookieWithName("Access-Token").description("인증 토큰")
+    };
+
+    FieldDescriptor[] ANNIVERSARY_CREATE_REQUEST_FIELDS = {
+        fieldWithPath("name").description("기념일")
+            .attributes(getAttribute(AnniversaryCreateRequest.class, "name")),
+        fieldWithPath("date").description("날짜")
+            .attributes(getAttribute(AnniversaryCreateRequest.class, "date")),
+        fieldWithPath("remind").description("리마인드"),
+        fieldWithPath("emojiId").description("리마인드")
+            .attributes(getAttribute(AnniversaryCreateRequest.class, "emojiId")),
+    };
+
+    FieldDescriptor[] ANNIVERSARY_CREATE_RESPONSE = {
+        fieldWithPath("data.anniversaryId").type(NUMBER).description("기념일 PK"),
+        fieldWithPath("data").type(OBJECT).description("데이터"),
+        fieldWithPath("code").type(NUMBER).description("응답 코드"),
+        fieldWithPath("message").type(STRING).description("응답 메시지")
+    };
+
+    RequestCookiesSnippet ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(TOKEN_COOKIE_DESCRIPTORS);
+    RequestFieldsSnippet ANNIVERSARY_CREATE_REQUEST_SNIPPET = requestFields(ANNIVERSARY_CREATE_REQUEST_FIELDS);
+    ResponseFieldsSnippet ANNIVERSARY_CREATE_RESPONSE_SNIPPET = responseFields(ANNIVERSARY_CREATE_RESPONSE);
+
+    static String createIdentifier(
+        final String name,
+        final int code
+    ) {
+        return String.format("%s/%d", name, code);
+    }
+}

--- a/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/integrationtest/AnniversaryReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/integrationtest/AnniversaryReadIntegrationTest.java
@@ -1,0 +1,48 @@
+package project.dailyge.app.test.anniversary.integrationtest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import project.dailyge.app.common.DatabaseTestBase;
+import project.dailyge.app.core.anniversary.application.AnniversaryReadService;
+import project.dailyge.app.core.anniversary.application.AnniversaryWriteService;
+import project.dailyge.app.core.anniversary.application.command.AnniversaryCreateCommand;
+import project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage;
+import project.dailyge.app.core.anniversary.exception.AnniversaryTypeException;
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+
+import java.time.LocalDateTime;
+
+@DisplayName("[IntegrationTest] 기념일 조회 통합 테스트")
+class AnniversaryReadIntegrationTest extends DatabaseTestBase {
+
+    @Autowired
+    private AnniversaryWriteService anniversaryWriteService;
+
+    @Autowired
+    private AnniversaryReadService anniversaryReadService;
+
+    @Test
+    @DisplayName("기념일이 존재하면 ID로 찾을 수 있다.")
+    void whenAnniversaryExistsThenCanFindById() {
+        final LocalDateTime now = LocalDateTime.now();
+        final String name = "부모님 결혼 기념일";
+        final boolean remind = false;
+        final AnniversaryCreateCommand command = new AnniversaryCreateCommand(name, now, remind, null);
+        final Long newAnniversaryId = anniversaryWriteService.save(dailygeUser, command);
+
+        final AnniversaryJpaEntity findAnniversary = anniversaryReadService.findById(newAnniversaryId);
+        assertNotNull(findAnniversary);
+    }
+
+    @Test
+    @DisplayName("기념일이 존재하지 않으면 AnniversaryTypeException이 발생한다..")
+    void whenAnniversaryNotExistsThenAnniversaryTypeExceptionShouldBeHappen() {
+        final Long invalidAnniversaryId = Long.MAX_VALUE;
+        assertThatThrownBy(() -> anniversaryReadService.findById(invalidAnniversaryId))
+            .isInstanceOf(AnniversaryTypeException.class)
+            .hasMessage(AnniversaryCodeAndMessage.ANNIVERSARY_NOT_FOUND.message());
+    }
+}

--- a/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/integrationtest/AnniversaryReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/integrationtest/AnniversaryReadIntegrationTest.java
@@ -38,7 +38,7 @@ class AnniversaryReadIntegrationTest extends DatabaseTestBase {
     }
 
     @Test
-    @DisplayName("기념일이 존재하지 않으면 AnniversaryTypeException이 발생한다..")
+    @DisplayName("기념일이 존재하지 않으면 AnniversaryTypeException이 발생한다.")
     void whenAnniversaryNotExistsThenAnniversaryTypeExceptionShouldBeHappen() {
         final Long invalidAnniversaryId = Long.MAX_VALUE;
         assertThatThrownBy(() -> anniversaryReadService.findById(invalidAnniversaryId))

--- a/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/integrationtest/AnniversarySaveIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/integrationtest/AnniversarySaveIntegrationTest.java
@@ -1,0 +1,80 @@
+package project.dailyge.app.test.anniversary.integrationtest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import project.dailyge.app.common.DatabaseTestBase;
+import project.dailyge.app.core.anniversary.application.AnniversaryReadService;
+import project.dailyge.app.core.anniversary.application.AnniversaryWriteService;
+import project.dailyge.app.core.anniversary.application.command.AnniversaryCreateCommand;
+import project.dailyge.app.core.anniversary.exception.AnniversaryCodeAndMessage;
+import project.dailyge.app.core.anniversary.exception.AnniversaryTypeException;
+import project.dailyge.app.core.anniversary.facade.AnniversaryFacade;
+import project.dailyge.app.core.emoji.exception.EmojiCodeAndMessage;
+import project.dailyge.app.core.emoji.exception.EmojiTypeException;
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+
+import java.time.LocalDateTime;
+
+@DisplayName("[IntegrationTest] 기념일 저장 통합 테스트")
+class AnniversarySaveIntegrationTest extends DatabaseTestBase {
+
+    @Autowired
+    private AnniversaryFacade anniversaryFacade;
+
+    @Autowired
+    private AnniversaryWriteService anniversaryWriteService;
+
+    @Autowired
+    private AnniversaryReadService anniversaryReadService;
+
+    @Test
+    @DisplayName("기념일이 저장되면 ID가 null이 아니다.")
+    void whenSaveAnniversaryThenIdShouldBeNotNull() {
+        final LocalDateTime now = LocalDateTime.now();
+        final String name = "부모님 결혼 기념일";
+        final boolean remind = false;
+        final AnniversaryCreateCommand command = new AnniversaryCreateCommand(name, now, remind, null);
+        final Long newAnniversaryId = anniversaryWriteService.save(dailygeUser, command);
+
+        assertNotNull(newAnniversaryId);
+
+        final AnniversaryJpaEntity findAnniversary = anniversaryReadService.findById(newAnniversaryId);
+        assertAll(
+            () -> assertEquals(name, findAnniversary.getName()),
+            () -> assertEquals(remind, findAnniversary.isRemind()),
+            () -> assertEquals(now, findAnniversary.getDate())
+        );
+    }
+
+    @Test
+    @DisplayName("이모티콘 ID가 존재할 때, 올바르지 않다면 EmojiTypeException이 발생한다.")
+    void whenEmojiIdExistsButInvalidThenEmojiTypeExceptionShouldBeHappen() {
+        final LocalDateTime now = LocalDateTime.now();
+        final String name = "부모님 결혼 기념일";
+        final boolean remind = false;
+        final Long invalidEmojiId = Long.MAX_VALUE;
+        final AnniversaryCreateCommand command = new AnniversaryCreateCommand(name, now, remind, invalidEmojiId);
+        assertThatThrownBy(() -> anniversaryFacade.save(dailygeUser, command))
+            .isInstanceOf(EmojiTypeException.class)
+            .hasMessage(EmojiCodeAndMessage.EMOJI_NOT_FOUND.message());
+    }
+
+    @Test
+    @DisplayName("중복된 기념일이 저장되면 AnniversaryTypeException이 발생한다.")
+    void whenDuplicatedAnniversaryThenAnniversaryTypeExceptionShouldBeHappen() {
+        final LocalDateTime now = LocalDateTime.now();
+        final String name = "부모님 결혼 기념일";
+        final boolean remind = false;
+        final AnniversaryCreateCommand command = new AnniversaryCreateCommand(name, now, remind, null);
+        anniversaryWriteService.save(dailygeUser, command);
+
+        assertThatThrownBy(() -> anniversaryWriteService.save(dailygeUser, command))
+            .isInstanceOf(AnniversaryTypeException.class)
+            .hasMessage(AnniversaryCodeAndMessage.DUPLICATED_ANNIVERSARY.message());
+    }
+}

--- a/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/integrationtest/AnniversarySaveIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/anniversary/integrationtest/AnniversarySaveIntegrationTest.java
@@ -19,6 +19,7 @@ import project.dailyge.app.core.emoji.exception.EmojiTypeException;
 import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @DisplayName("[IntegrationTest] 기념일 저장 통합 테스트")
 class AnniversarySaveIntegrationTest extends DatabaseTestBase {
@@ -35,7 +36,7 @@ class AnniversarySaveIntegrationTest extends DatabaseTestBase {
     @Test
     @DisplayName("기념일이 저장되면 ID가 null이 아니다.")
     void whenSaveAnniversaryThenIdShouldBeNotNull() {
-        final LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         final String name = "부모님 결혼 기념일";
         final boolean remind = false;
         final AnniversaryCreateCommand command = new AnniversaryCreateCommand(name, now, remind, null);
@@ -47,7 +48,7 @@ class AnniversarySaveIntegrationTest extends DatabaseTestBase {
         assertAll(
             () -> assertEquals(name, findAnniversary.getName()),
             () -> assertEquals(remind, findAnniversary.isRemind()),
-            () -> assertEquals(now, findAnniversary.getDate())
+            () -> assertEquals(now.toLocalDate(), findAnniversary.getDate().toLocalDate())
         );
     }
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/emoji/integrationtest/EmojiReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/emoji/integrationtest/EmojiReadIntegrationTest.java
@@ -9,7 +9,7 @@ import project.dailyge.app.core.emoji.application.EmojiReadService;
 import project.dailyge.app.core.emoji.exception.EmojiCodeAndMessage;
 import project.dailyge.app.core.emoji.exception.EmojiTypeException;
 
-@DisplayName("[IntegrationTest] Emoji 저장 통합 테스트")
+@DisplayName("[IntegrationTest] Emoji 조회 통합 테스트")
 class EmojiReadIntegrationTest extends DatabaseTestBase {
 
     @Autowired

--- a/dailyge-api/src/test/java/project/dailyge/app/test/emoji/integrationtest/EmojiReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/emoji/integrationtest/EmojiReadIntegrationTest.java
@@ -1,0 +1,26 @@
+package project.dailyge.app.test.emoji.integrationtest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import project.dailyge.app.common.DatabaseTestBase;
+import project.dailyge.app.core.emoji.application.EmojiReadService;
+import project.dailyge.app.core.emoji.exception.EmojiCodeAndMessage;
+import project.dailyge.app.core.emoji.exception.EmojiTypeException;
+
+@DisplayName("[IntegrationTest] Emoji 저장 통합 테스트")
+class EmojiReadIntegrationTest extends DatabaseTestBase {
+
+    @Autowired
+    private EmojiReadService emojiReadService;
+
+    @Test
+    @DisplayName("이모티콘이 존재하지 않으면 EmojiTypeException이 발생한다.")
+    void whenEmojiNotExistsThenEmojiTypeExceptionShouldBeHappen() {
+        final Long invalidEmojiId = Long.MAX_VALUE;
+        assertThatThrownBy(() -> emojiReadService.validateExists(invalidEmojiId))
+            .isInstanceOf(EmojiTypeException.class)
+            .hasMessage(EmojiCodeAndMessage.EMOJI_NOT_FOUND.message());
+    }
+}

--- a/dailyge-api/src/test/java/project/dailyge/app/test/emoji/integrationtest/EmojiSaveIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/emoji/integrationtest/EmojiSaveIntegrationTest.java
@@ -1,0 +1,28 @@
+package project.dailyge.app.test.emoji.integrationtest;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import project.dailyge.app.common.DatabaseTestBase;
+import project.dailyge.app.core.emoji.application.EmojiReadService;
+import project.dailyge.app.core.emoji.application.EmojiWriteService;
+import project.dailyge.entity.emoji.EmojiJpaEntity;
+
+@DisplayName("[IntegrationTest] Emoji 저장 통합 테스트")
+class EmojiSaveIntegrationTest extends DatabaseTestBase {
+
+    @Autowired
+    private EmojiWriteService emojiWriteService;
+
+    @Autowired
+    private EmojiReadService emojiReadService;
+
+    @Test
+    @DisplayName("이모티콘이 존재하면 예외가 발생하지 않는다.")
+    void whenSaveEmojiThenCanFindById() {
+        final EmojiJpaEntity emoji = new EmojiJpaEntity(":+1::skin-tone-6:");
+        final Long newEmojiId = emojiWriteService.save(emoji);
+        assertDoesNotThrow(() -> emojiReadService.validateExists(newEmojiId));
+    }
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/anniversary/AnniversaryEntityReadRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/anniversary/AnniversaryEntityReadRepository.java
@@ -1,7 +1,10 @@
 package project.dailyge.entity.anniversary;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface AnniversaryEntityReadRepository {
     Optional<AnniversaryJpaEntity> findById(Long anniversaryId);
+
+    boolean exists(String name, LocalDateTime date);
 }

--- a/storage/rdb/src/main/java/project/dailyge/entity/anniversary/AnniversaryEntityReadRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/anniversary/AnniversaryEntityReadRepository.java
@@ -1,0 +1,7 @@
+package project.dailyge.entity.anniversary;
+
+import java.util.Optional;
+
+public interface AnniversaryEntityReadRepository {
+    Optional<AnniversaryJpaEntity> findById(Long anniversaryId);
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/anniversary/AnniversaryEntityWriteRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/anniversary/AnniversaryEntityWriteRepository.java
@@ -1,0 +1,5 @@
+package project.dailyge.entity.anniversary;
+
+public interface AnniversaryEntityWriteRepository {
+    Long save(AnniversaryJpaEntity anniversary);
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/anniversary/AnniversaryJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/anniversary/AnniversaryJpaEntity.java
@@ -1,0 +1,63 @@
+package project.dailyge.entity.anniversary;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.dailyge.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "anniversaries")
+public class AnniversaryJpaEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "date")
+    private LocalDateTime date;
+
+    @Column(name = "remind")
+    private boolean remind;
+
+    @Column(name = "emoji_id")
+    private Long emojiId;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    public AnniversaryJpaEntity(
+        final String name,
+        final LocalDateTime date,
+        final boolean remind,
+        final Long emojiId,
+        final Long userId
+    ) {
+        this(null, name, date, remind, emojiId, userId);
+    }
+
+    public AnniversaryJpaEntity(
+        final Long id,
+        final String name,
+        final LocalDateTime date,
+        final boolean remind,
+        final Long emojiId,
+        final Long userId
+    ) {
+        this.id = id;
+        this.name = name;
+        this.date = date;
+        this.remind = remind;
+        this.emojiId = emojiId;
+        this.userId = userId;
+    }
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiEntityReadRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiEntityReadRepository.java
@@ -1,0 +1,7 @@
+package project.dailyge.entity.emoji;
+
+import java.util.Optional;
+
+public interface EmojiEntityReadRepository {
+    Optional<EmojiJpaEntity> findById(Long emojiId);
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiEntityWriteRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiEntityWriteRepository.java
@@ -1,0 +1,5 @@
+package project.dailyge.entity.emoji;
+
+public interface EmojiEntityWriteRepository {
+    Long save(EmojiJpaEntity emoji);
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiJpaEntity.java
@@ -22,7 +22,14 @@ public class EmojiJpaEntity extends BaseEntity {
     private String emoji;
 
     public EmojiJpaEntity(final String emoji) {
+        validate(emoji);
         this.emoji = emoji;
+    }
+
+    private void validate(final String emoji) {
+        if (emoji.isBlank()) {
+            throw new IllegalArgumentException("올바른 이모티콘을 입력해주세요.");
+        }
     }
 
     public EmojiJpaEntity(

--- a/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiJpaEntity.java
@@ -20,4 +20,16 @@ public class EmojiJpaEntity extends BaseEntity {
 
     @Column(name = "emoji")
     private String emoji;
+
+    public EmojiJpaEntity(final String emoji) {
+        this.emoji = emoji;
+    }
+
+    public EmojiJpaEntity(
+        final Long id,
+        final String emoji
+    ) {
+        this.id = id;
+        this.emoji = emoji;
+    }
 }

--- a/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/emoji/EmojiJpaEntity.java
@@ -1,0 +1,23 @@
+package project.dailyge.entity.emoji;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.dailyge.entity.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "emojis")
+public class EmojiJpaEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "emoji")
+    private String emoji;
+}

--- a/storage/rdb/src/test/java/project/dailyge/entity/test/anniversary/AnniversaryJpaEntityUnitTest.java
+++ b/storage/rdb/src/test/java/project/dailyge/entity/test/anniversary/AnniversaryJpaEntityUnitTest.java
@@ -1,0 +1,39 @@
+package project.dailyge.entity.test.anniversary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import project.dailyge.entity.anniversary.AnniversaryJpaEntity;
+
+import java.time.LocalDateTime;
+
+@DisplayName("[UnitTest] Anniversary 엔티티 단위 테스트")
+class AnniversaryJpaEntityUnitTest {
+
+    private AnniversaryJpaEntity anniversary;
+
+    @BeforeEach
+    void setUp() {
+        anniversary = new AnniversaryJpaEntity(
+            "생일",
+            LocalDateTime.of(2024, 10, 10, 0, 0),
+            true,
+            1L,
+            1L
+        );
+    }
+
+    @Test
+    @DisplayName("올바른 인자로 객체가 생성되었는지 검증")
+    void whenValidParameterThenAnniversaryShouldBeCreated() {
+        assertAll(
+            () -> assertThat(anniversary.getName()).isEqualTo("생일"),
+            () -> assertThat(anniversary.getDate()).isEqualTo(LocalDateTime.of(2024, 10, 10, 0, 0)),
+            () -> assertThat(anniversary.isRemind()).isTrue(),
+            () -> assertThat(anniversary.getEmojiId()).isEqualTo(1L),
+            () -> assertThat(anniversary.getUserId()).isEqualTo(1L)
+        );
+    }
+}

--- a/storage/rdb/src/test/java/project/dailyge/entity/test/emoji/EmojiJpaEntityUnitTest.java
+++ b/storage/rdb/src/test/java/project/dailyge/entity/test/emoji/EmojiJpaEntityUnitTest.java
@@ -1,0 +1,39 @@
+package project.dailyge.entity.test.emoji;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import project.dailyge.entity.emoji.EmojiJpaEntity;
+
+@DisplayName("[UnitTest] 이모티콘 엔티티 테스트")
+class EmojiJpaEntityUnitTest {
+
+    private EmojiJpaEntity emoji;
+
+    @BeforeEach
+    void setUp() {
+        emoji = new EmojiJpaEntity("😀");
+    }
+
+    @Test
+    @DisplayName("올바른 이모티콘을 입력하면 객체가 생성된다.")
+    void whenValidEmojiThenObjectIsCreated() {
+        final EmojiJpaEntity validEmoji = new EmojiJpaEntity("😀");
+        assertAll(
+            () -> assertThat(validEmoji.getEmoji()).isEqualTo("😀"),
+            () -> assertThat(validEmoji.getId()).isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("빈 문자열을 입력하면 IllegalArgumentException이 발생한다.")
+    void whenEmojiIsBlankThenThrowIllegalArgumentException() {
+        assertThatThrownBy(() ->
+            new EmojiJpaEntity(" ")
+        ).isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("올바른 이모티콘을 입력해주세요.");
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

기념일 등록 API를 개발했습니다. 이전 프로젝트에서 이모티콘을 Enum으로 관리해 봤는데, 큰 불편은 없었습니다. 다만 그때는 이모티콘 개수가 조금 적었는데, 이번에는 이모티콘이 많아지는 상황을 고려해 테이블로 관리할 수 있도록 만들었습니다.

- [x] 기념일, 이모티콘 엔티티 매핑
- [x] 기념일 schema.sql 추가
- [x] 기념일 등록 API 개발
- [x] 테스트 작성

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-344)
