### PR TITLE
[DLG-361] 회고 조회 시 전체페이지 개수를 추가한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/web/OffsetPagingArgumentResolver.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/web/OffsetPagingArgumentResolver.java
@@ -13,8 +13,8 @@ import project.dailyge.app.page.PageFactory;
 @Order(3)
 public class OffsetPagingArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private static final String PAGE = "page";
-    private static final String LIMIT = "limit";
+    private static final String PAGE_NUMBER = "pageNumber";
+    private static final String PAGE_SIZE = "pageSize";
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
@@ -33,8 +33,8 @@ public class OffsetPagingArgumentResolver implements HandlerMethodArgumentResolv
 
     private CustomPageable createPage(final NativeWebRequest webRequest) {
         return PageFactory.createPage(
-            webRequest.getParameter(PAGE),
-            webRequest.getParameter(LIMIT)
+            webRequest.getParameter(PAGE_NUMBER),
+            webRequest.getParameter(PAGE_SIZE)
         );
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/RetrospectReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/RetrospectReadService.java
@@ -9,4 +9,6 @@ public interface RetrospectReadService {
     RetrospectJpaEntity findById(Long retrospectId);
 
     List<RetrospectJpaEntity> findRetrospectByPage(DailygeUser dailygeUser, CustomPageable page);
+
+    int findTotalCount(DailygeUser dailygeUser);
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/RetrospectReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/RetrospectReadService.java
@@ -10,5 +10,5 @@ public interface RetrospectReadService {
 
     List<RetrospectJpaEntity> findRetrospectByPage(DailygeUser dailygeUser, CustomPageable page);
 
-    int findTotalCount(DailygeUser dailygeUser);
+    long findTotalCount(DailygeUser dailygeUser);
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
@@ -33,4 +33,9 @@ class RetrospectReadUseCase implements RetrospectReadService {
     ) {
         return retrospectEntityReadDao.findRetrospectByPage(dailygeUser.getId(), page);
     }
+
+    @Override
+    public int findTotalCount(final DailygeUser dailygeUser) {
+        return retrospectEntityReadDao.findTotalCount(dailygeUser.getId());
+    }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
@@ -35,7 +35,7 @@ class RetrospectReadUseCase implements RetrospectReadService {
     }
 
     @Override
-    public int findTotalCount(final DailygeUser dailygeUser) {
+    public long findTotalCount(final DailygeUser dailygeUser) {
         return retrospectEntityReadDao.findTotalCount(dailygeUser.getId());
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
@@ -43,12 +43,13 @@ public class RetrospectEntityReadDao implements RetrospectEntityReadRepository {
             .fetch();
     }
 
-    public int findTotalCount(final Long userId) {
-        return jpaQueryFactory.selectFrom(retrospectJpaEntity)
+    public long findTotalCount(final Long userId) {
+        return jpaQueryFactory.from(retrospectJpaEntity)
+            .select(retrospectJpaEntity.id.count())
             .where(
                 retrospectJpaEntity.userId.eq(userId)
                     .and(retrospectJpaEntity.deleted.eq(false))
             )
-            .fetch().size();
+            .fetchOne();
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
@@ -39,7 +39,7 @@ public class RetrospectEntityReadDao implements RetrospectEntityReadRepository {
             )
             .orderBy(retrospectJpaEntity.date.desc())
             .offset(page.getOffset())
-            .limit(page.getLimit())
+            .limit(page.getPageSize())
             .fetch();
     }
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
@@ -42,4 +42,13 @@ public class RetrospectEntityReadDao implements RetrospectEntityReadRepository {
             .limit(page.getLimit())
             .fetch();
     }
+
+    public int findTotalCount(final Long userId) {
+        return jpaQueryFactory.selectFrom(retrospectJpaEntity)
+            .where(
+                retrospectJpaEntity.userId.eq(userId)
+                    .and(retrospectJpaEntity.deleted.eq(false))
+            )
+            .fetch().size();
+    }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
@@ -10,6 +10,7 @@ import project.dailyge.app.common.annotation.PresentationLayer;
 import project.dailyge.app.common.response.ApiResponse;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.retrospect.application.RetrospectReadService;
+import project.dailyge.app.core.retrospect.presentation.response.RetrospectPageResponse;
 import project.dailyge.app.core.retrospect.presentation.response.RetrospectResponse;
 import project.dailyge.app.page.CustomPageable;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.OK;
@@ -22,13 +23,15 @@ public class RetrospectReadApi {
     private final RetrospectReadService retrospectReadService;
 
     @GetMapping
-    public ApiResponse<List<RetrospectResponse>> findMonthlyGoalsByCursor(
+    public ApiResponse<RetrospectPageResponse> findMonthlyGoalsByCursor(
         @LoginUser final DailygeUser dailygeUser,
         @OffsetPageable final CustomPageable page
     ) {
-        final List<RetrospectResponse> payload = retrospectReadService.findRetrospectByPage(dailygeUser, page).stream()
+        final List<RetrospectResponse> retrospects = retrospectReadService.findRetrospectByPage(dailygeUser, page).stream()
             .map(RetrospectResponse::new)
             .toList();
+        final int totalPageCount = retrospectReadService.findTotalCount(dailygeUser);
+        final RetrospectPageResponse payload = new RetrospectPageResponse(retrospects, page.getTotalPageCount(totalPageCount));
         return ApiResponse.from(OK, payload);
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
@@ -45,7 +45,7 @@ public class RetrospectReadApi {
                 final Long totalPageCount = page.getTotalPageCount(totalCountFuture.join());
                 return new RetrospectPageResponse(retrospects, totalPageCount);
             }).exceptionally(ex -> {
-                throw RetrospectTypeException.from(RETROSPECT_UN_RESOLVED_EXCEPTION);
+                throw RetrospectTypeException.from(ex.getMessage(), RETROSPECT_UN_RESOLVED_EXCEPTION);
             });
 
         return ApiResponse.from(OK, payloadFuture.join());

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
@@ -1,6 +1,7 @@
 package project.dailyge.app.core.retrospect.presentation;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,10 +11,12 @@ import project.dailyge.app.common.annotation.PresentationLayer;
 import project.dailyge.app.common.response.ApiResponse;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.retrospect.application.RetrospectReadService;
+import project.dailyge.app.core.retrospect.exception.RetrospectTypeException;
 import project.dailyge.app.core.retrospect.presentation.response.RetrospectPageResponse;
 import project.dailyge.app.core.retrospect.presentation.response.RetrospectResponse;
 import project.dailyge.app.page.CustomPageable;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.OK;
+import static project.dailyge.app.core.retrospect.exception.RetrospectCodeAndMessage.RETROSPECT_UN_RESOLVED_EXCEPTION;
 
 @RequiredArgsConstructor
 @RequestMapping(path = "/api/retrospects")
@@ -27,11 +30,24 @@ public class RetrospectReadApi {
         @LoginUser final DailygeUser dailygeUser,
         @OffsetPageable final CustomPageable page
     ) {
-        final List<RetrospectResponse> retrospects = retrospectReadService.findRetrospectByPage(dailygeUser, page).stream()
-            .map(RetrospectResponse::new)
-            .toList();
-        final int totalPageCount = retrospectReadService.findTotalCount(dailygeUser);
-        final RetrospectPageResponse payload = new RetrospectPageResponse(retrospects, page.getTotalPageCount(totalPageCount));
-        return ApiResponse.from(OK, payload);
+        final CompletableFuture<List<RetrospectResponse>> retrospectsFuture = CompletableFuture.supplyAsync(() ->
+            retrospectReadService.findRetrospectByPage(dailygeUser, page).stream()
+                .map(RetrospectResponse::new)
+                .toList());
+
+        final CompletableFuture<Long> totalCountFuture = CompletableFuture.supplyAsync(() ->
+            retrospectReadService.findTotalCount(dailygeUser)
+        );
+
+        final CompletableFuture<RetrospectPageResponse> payloadFuture = CompletableFuture.allOf(retrospectsFuture, totalCountFuture)
+            .thenApply(ignored -> {
+                final List<RetrospectResponse> retrospects = retrospectsFuture.join();
+                final Long totalPageCount = page.getTotalPageCount(totalCountFuture.join());
+                return new RetrospectPageResponse(retrospects, totalPageCount);
+            }).exceptionally(ex -> {
+                throw RetrospectTypeException.from(RETROSPECT_UN_RESOLVED_EXCEPTION);
+            });
+
+        return ApiResponse.from(OK, payloadFuture.join());
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
@@ -7,4 +7,11 @@ public record RetrospectPageResponse(
     int totalPageCount
 ) {
 
+    @Override
+    public String toString() {
+        return String.format(
+            "{\"retrospects\":\"%s\",\"totalPageCount\":\"%s\"}",
+            retrospects, totalPageCount
+        );
+    }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
@@ -1,0 +1,10 @@
+package project.dailyge.app.core.retrospect.presentation.response;
+
+import java.util.List;
+
+public record RetrospectPageResponse(
+    List<RetrospectResponse> retrospects,
+    int totalPageCount
+) {
+
+}

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record RetrospectPageResponse(
     List<RetrospectResponse> retrospects,
-    int totalPageCount
+    long totalPageCount
 ) {
 
     @Override

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/documentationtest/snippet/RetrospectSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/documentationtest/snippet/RetrospectSnippet.java
@@ -78,12 +78,14 @@ public interface RetrospectSnippet {
     };
 
     FieldDescriptor[] RETROSPECT_READ_RESPONSE_FIELDS = {
-        fieldWithPath("data").type(ARRAY).description("데이터"),
-        fieldWithPath("data.[].id").type(NUMBER).description("회고 ID"),
-        fieldWithPath("data.[].title").type(STRING).description("회고 제목"),
-        fieldWithPath("data.[].content").type(STRING).description("회고 내용"),
-        fieldWithPath("data.[].date").type(STRING).description("날짜"),
-        fieldWithPath("data.[].isPublic").type(BOOLEAN).description("공개 여부"),
+        fieldWithPath("data").type(OBJECT).description("데이터"),
+        fieldWithPath("data.retrospects").type(ARRAY).description("데이터"),
+        fieldWithPath("data.retrospects.[].id").type(NUMBER).description("회고 ID"),
+        fieldWithPath("data.retrospects.[].title").type(STRING).description("회고 제목"),
+        fieldWithPath("data.retrospects.[].content").type(STRING).description("회고 내용"),
+        fieldWithPath("data.retrospects.[].date").type(STRING).description("날짜"),
+        fieldWithPath("data.retrospects.[].isPublic").type(BOOLEAN).description("공개 여부"),
+        fieldWithPath("data.totalPageCount").type(NUMBER).description("공개 여부"),
         fieldWithPath("code").type(NUMBER).description("응답 코드"),
         fieldWithPath("message").type(STRING).description("응답 메시지")
     };

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/documentationtest/snippet/RetrospectSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/documentationtest/snippet/RetrospectSnippet.java
@@ -38,8 +38,8 @@ public interface RetrospectSnippet {
     };
 
     ParameterDescriptor[] RETROSPECT_PAGING_PATH_PARAMETER_DESCRIPTORS = {
-        parameterWithName("page").description("페이지 번호").optional(),
-        parameterWithName("limit").description("최대 개수").optional(),
+        parameterWithName("pageNumber").description("페이지 번호").optional(),
+        parameterWithName("pageSize").description("페이지 크기").optional(),
     };
 
     FieldDescriptor[] RETROSPECT_CREATE_REQUEST_FIELDS = {

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
@@ -63,4 +63,16 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
 
         assertTrue(findRetrospects.isEmpty());
     }
+
+
+    @Test
+    @DisplayName("자신의 회고 전체 개수만 반환한다.")
+    void whenFindTotalCountThenResultShouldBeMyTotalRetrospectCount() {
+        final RetrospectCreateCommand createCommand = new RetrospectCreateCommand("회고 제목", "회고 내용", now.atTime(0, 0, 0, 0), false);
+        retrospectWriteService.save(invalidUser, createCommand);
+
+        final int totalCount = retrospectReadService.findTotalCount(dailygeUser);
+
+        assertEquals(10, totalCount);
+    }
 }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
@@ -71,7 +71,7 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
         final RetrospectCreateCommand createCommand = new RetrospectCreateCommand("회고 제목", "회고 내용", now.atTime(0, 0, 0, 0), false);
         retrospectWriteService.save(invalidUser, createCommand);
 
-        final int totalCount = retrospectReadService.findTotalCount(dailygeUser);
+        final long totalCount = retrospectReadService.findTotalCount(dailygeUser);
 
         assertEquals(10, totalCount);
     }

--- a/support/src/main/java/project/dailyge/app/page/CustomPageable.java
+++ b/support/src/main/java/project/dailyge/app/page/CustomPageable.java
@@ -5,20 +5,20 @@ import lombok.Getter;
 @Getter
 public class CustomPageable {
 
-    private final Integer pageNumber;
-    private final Integer pageSize;
+    private final int pageNumber;
+    private final int pageSize;
 
     private CustomPageable(
-        final Integer pageNumber,
-        final Integer pageSize
+        final int pageNumber,
+        final int pageSize
     ) {
         this.pageNumber = pageNumber;
         this.pageSize = pageSize;
     }
 
     public static CustomPageable createPage(
-        final Integer page,
-        final Integer limit
+        final int page,
+        final int limit
     ) {
         return new CustomPageable(page, limit);
     }

--- a/support/src/main/java/project/dailyge/app/page/CustomPageable.java
+++ b/support/src/main/java/project/dailyge/app/page/CustomPageable.java
@@ -28,7 +28,7 @@ public class CustomPageable {
     }
 
     public int getTotalPageCount(final int totalCount) {
-        return (int) Math.ceil((double) totalCount / limit);
+        return (totalCount - 1) / limit + 1;
     }
 
     @Override

--- a/support/src/main/java/project/dailyge/app/page/CustomPageable.java
+++ b/support/src/main/java/project/dailyge/app/page/CustomPageable.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 @Getter
 public class CustomPageable {
 
-    private final Integer page;
-    private final Integer limit;
+    private final Integer pageNumber;
+    private final Integer pageSize;
 
     private CustomPageable(
-        final Integer page,
-        final Integer limit
+        final Integer pageNumber,
+        final Integer pageSize
     ) {
-        this.page = page;
-        this.limit = limit;
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
     }
 
     public static CustomPageable createPage(
@@ -24,15 +24,15 @@ public class CustomPageable {
     }
 
     public int getOffset() {
-        return (page - 1) * limit;
+        return (pageNumber - 1) * pageSize;
     }
 
     public int getTotalPageCount(final int totalCount) {
-        return (totalCount - 1) / limit + 1;
+        return (totalCount - 1) / pageSize + 1;
     }
 
     @Override
     public String toString() {
-        return String.format("{\"page\": \"%s\", \"limit\": \"%s\"}", page, limit);
+        return String.format("{\"page\": \"%s\", \"limit\": \"%s\"}", pageNumber, pageSize);
     }
 }

--- a/support/src/main/java/project/dailyge/app/page/CustomPageable.java
+++ b/support/src/main/java/project/dailyge/app/page/CustomPageable.java
@@ -27,7 +27,7 @@ public class CustomPageable {
         return (pageNumber - 1) * pageSize;
     }
 
-    public int getTotalPageCount(final int totalCount) {
+    public long getTotalPageCount(final long totalCount) {
         return (totalCount - 1) / pageSize + 1;
     }
 

--- a/support/src/main/java/project/dailyge/app/page/CustomPageable.java
+++ b/support/src/main/java/project/dailyge/app/page/CustomPageable.java
@@ -27,6 +27,10 @@ public class CustomPageable {
         return (page - 1) * limit;
     }
 
+    public int getTotalPageCount(final int totalCount) {
+        return (int) Math.ceil((double) totalCount / limit);
+    }
+
     @Override
     public String toString() {
         return String.format("{\"page\": \"%s\", \"limit\": \"%s\"}", page, limit);

--- a/support/src/main/java/project/dailyge/app/page/PageFactory.java
+++ b/support/src/main/java/project/dailyge/app/page/PageFactory.java
@@ -2,59 +2,60 @@ package project.dailyge.app.page;
 
 public final class PageFactory {
 
-    private static final int DEFAULT_PAGE = 1;
-    private static final int DEFAULT_LIMIT = 10;
-    private static final int MAX_LIMIT = 30;
+    private static final int DEFAULT_PAGE_NUMBER = 1;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int MIN_PAGE_SIZE = 5;
+    private static final int MAX_PAGE_SIZE = 30;
 
     private PageFactory() {
         throw new AssertionError("올바른 방식으로 생성자를 호출해주세요.");
     }
 
     public static CustomPageable createPage(
-        final String page,
-        final String limit
+        final String pageNumber,
+        final String pageSize
     ) {
         return CustomPageable.createPage(
-            getPage(page),
-            getLimit(limit)
+            getPageNumber(pageNumber),
+            getPageSize(pageSize)
         );
     }
 
-    private static Integer getPage(final String page) {
-        final Integer parsedPage = parsePage(page);
-        if (parsedPage < DEFAULT_PAGE) {
-            return DEFAULT_PAGE;
+    private static int getPageNumber(final String pageNumber) {
+        final int parsedPageNumber = parsePageNumber(pageNumber);
+        if (parsedPageNumber < DEFAULT_PAGE_NUMBER) {
+            return DEFAULT_PAGE_NUMBER;
         }
-        return parsedPage;
+        return parsedPageNumber;
     }
 
-    private static Integer parsePage(final String page) {
-        if (page == null) {
-            return DEFAULT_PAGE;
+    private static int parsePageNumber(final String pageNumber) {
+        if (pageNumber == null) {
+            return DEFAULT_PAGE_NUMBER;
         }
         try {
-            return Integer.parseInt(page);
+            return Integer.parseInt(pageNumber);
         } catch (NumberFormatException exception) {
-            return DEFAULT_PAGE;
+            return DEFAULT_PAGE_NUMBER;
         }
     }
 
-    private static Integer getLimit(final String limit) {
-        final Integer pageSizeLimit = parseLimit(limit);
-        if (pageSizeLimit < 1 || pageSizeLimit > MAX_LIMIT) {
-            return DEFAULT_LIMIT;
+    private static int getPageSize(final String pageSize) {
+        final int parsedPageSize = parsePageSize(pageSize);
+        if (parsedPageSize < 1 || parsedPageSize > MAX_PAGE_SIZE || parsedPageSize < MIN_PAGE_SIZE) {
+            return DEFAULT_PAGE_SIZE;
         }
-        return pageSizeLimit;
+        return parsedPageSize;
     }
 
-    private static Integer parseLimit(final String limit) {
-        if (limit == null) {
-            return DEFAULT_LIMIT;
+    private static int parsePageSize(final String pageSize) {
+        if (pageSize == null) {
+            return DEFAULT_PAGE_SIZE;
         }
         try {
-            return Integer.parseInt(limit);
+            return Integer.parseInt(pageSize);
         } catch (NumberFormatException exception) {
-            return DEFAULT_LIMIT;
+            return DEFAULT_PAGE_SIZE;
         }
     }
 }

--- a/support/src/main/java/project/dailyge/app/page/PageFactory.java
+++ b/support/src/main/java/project/dailyge/app/page/PageFactory.java
@@ -42,7 +42,7 @@ public final class PageFactory {
 
     private static int getPageSize(final String pageSize) {
         final int parsedPageSize = parsePageSize(pageSize);
-        if (parsedPageSize < 1 || parsedPageSize > MAX_PAGE_SIZE || parsedPageSize < MIN_PAGE_SIZE) {
+        if (parsedPageSize < MIN_PAGE_SIZE || parsedPageSize > MAX_PAGE_SIZE) {
             return DEFAULT_PAGE_SIZE;
         }
         return parsedPageSize;

--- a/support/src/test/java/project/dailyge/support/test/page/CustomPageableUnitTest.java
+++ b/support/src/test/java/project/dailyge/support/test/page/CustomPageableUnitTest.java
@@ -12,36 +12,36 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @DisplayName("[UnitTest] Page 단위 테스트")
 class CustomPageableUnitTest {
 
-    private static final int PAGE = 1;
-    private static final int LIMIT = 10;
+    private static final int PAGE_NUMBER = 1;
+    private static final int PAGE_SIZE = 10;
     private CustomPageable page;
 
     @BeforeEach
     void setUp() {
-        page = CustomPageable.createPage(PAGE, LIMIT);
+        page = CustomPageable.createPage(PAGE_NUMBER, PAGE_SIZE);
     }
 
     @Test
     @DisplayName("Page 생성 시 올바르게 초기화 된다.")
     void whenCreatePageThenInitializeCorrectly() {
         assertNotNull(page);
-        assertEquals(PAGE, page.getPage());
-        assertEquals(LIMIT, page.getLimit());
+        assertEquals(PAGE_NUMBER, page.getPageNumber());
+        assertEquals(PAGE_SIZE, page.getPageSize());
     }
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 3, 10, 100})
     @DisplayName("Page를 통한 offset이 정확하게 계산이 된다.")
-    void whenCalculatePageOffsetThenResultShouldBeCorrectly(final int page) {
-        final CustomPageable newPage = CustomPageable.createPage(page, LIMIT);
+    void whenCalculatePageOffsetThenResultShouldBeCorrectly(final int pageNumber) {
+        final CustomPageable newPage = CustomPageable.createPage(pageNumber, PAGE_SIZE);
 
-        assertEquals((page - 1) * LIMIT, newPage.getOffset());
+        assertEquals((pageNumber - 1) * PAGE_SIZE, newPage.getOffset());
     }
 
     @Test
     @DisplayName("limit에 따른 전체 페이지 개수를 올림하여 계산한다.")
     void whenCalculateTotalPageCountThenResultShouldBeCorrectly() {
-        final CustomPageable newPage = CustomPageable.createPage(PAGE, LIMIT);
+        final CustomPageable newPage = CustomPageable.createPage(PAGE_NUMBER, PAGE_SIZE);
 
         assertEquals(4, newPage.getTotalPageCount(33));
     }

--- a/support/src/test/java/project/dailyge/support/test/page/CustomPageableUnitTest.java
+++ b/support/src/test/java/project/dailyge/support/test/page/CustomPageableUnitTest.java
@@ -39,6 +39,14 @@ class CustomPageableUnitTest {
     }
 
     @Test
+    @DisplayName("limit에 따른 전체 페이지 개수를 올림하여 계산한다.")
+    void whenCalculateTotalPageCountThenResultShouldBeCorrectly() {
+        final CustomPageable newPage = CustomPageable.createPage(PAGE, LIMIT);
+
+        assertEquals(4, newPage.getTotalPageCount(33));
+    }
+
+    @Test
     @DisplayName("Page 객체의 toString 메서드는 올바른 JSON 형식의 문자열을 반환한다.")
     void whenToStringCalledThenReturnJsonFormatString() {
         assertEquals("{\"page\": \"1\", \"limit\": \"10\"}", page.toString());

--- a/support/src/test/java/project/dailyge/support/test/page/PageFactoryUnitTest.java
+++ b/support/src/test/java/project/dailyge/support/test/page/PageFactoryUnitTest.java
@@ -10,52 +10,52 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @DisplayName("[UnitTest] PageFactory 단위 테스트")
 class PageFactoryUnitTest {
 
-    private static final int DEFAULT_PAGE = 1;
-    private static final int DEFAULT_LIMIT = 10;
+    private static final int DEFAULT_PAGE_NUMBER = 1;
+    private static final int DEFAULT_PAGE_SIZE = 10;
 
     @Test
-    @DisplayName("유효한 page와 limit로 Page를 생성하면, 올바르게 생성된다.")
+    @DisplayName("유효한 page와 pageSize로 Page를 생성하면, 올바르게 생성된다.")
     void whenCreatePageWithValidArgumentThenCorrectlyCreatedPage() {
-        final String page = "10";
-        final String limit = "20";
-        final CustomPageable newPage = PageFactory.createPage(page, limit);
+        final String pageNumber = "10";
+        final String pageSize = "20";
+        final CustomPageable newPage = PageFactory.createPage(pageNumber, pageSize);
 
         assertNotNull(newPage);
-        assertEquals(Integer.parseInt(page), newPage.getPage());
-        assertEquals(Integer.parseInt(limit), newPage.getLimit());
+        assertEquals(Integer.parseInt(pageNumber), newPage.getPageNumber());
+        assertEquals(Integer.parseInt(pageSize), newPage.getPageSize());
     }
 
     @Test
-    @DisplayName("유효하지 않는 page와 limit이면, 기본 설정값으로 생성된다.")
+    @DisplayName("유효하지 않는 page와 pageSize이면, 기본 설정값으로 생성된다.")
     void whenCreatePageWithInvalidArgumentThenDefaultSettingsUsed() {
-        final String page = "-1";
-        final String limit = "-1";
-        final CustomPageable newPage = PageFactory.createPage(page, limit);
+        final String pageNumber = "-1";
+        final String pageSize = "-1";
+        final CustomPageable newPage = PageFactory.createPage(pageNumber, pageSize);
 
         assertNotNull(newPage);
-        assertEquals(DEFAULT_PAGE, newPage.getPage());
-        assertEquals(DEFAULT_LIMIT, newPage.getLimit());
+        assertEquals(DEFAULT_PAGE_NUMBER, newPage.getPageNumber());
+        assertEquals(DEFAULT_PAGE_SIZE, newPage.getPageSize());
     }
 
     @Test
-    @DisplayName("page와 limit가 null이면, 기본 설정값으로 생성된다.")
-    void whenPageAndLimitIsNullThenDefaultSettingsUsed() {
+    @DisplayName("page와 pageSize가 null이면, 기본 설정값으로 생성된다.")
+    void whenPageAndpageSizeIsNullThenDefaultSettingsUsed() {
         final CustomPageable newPage = PageFactory.createPage(null, null);
 
         assertNotNull(newPage);
-        assertEquals(DEFAULT_PAGE, newPage.getPage());
-        assertEquals(DEFAULT_LIMIT, newPage.getLimit());
+        assertEquals(DEFAULT_PAGE_NUMBER, newPage.getPageNumber());
+        assertEquals(DEFAULT_PAGE_SIZE, newPage.getPageSize());
     }
 
     @Test
-    @DisplayName("limit가 최대 limit 보다 크면, 기본 limit값으로 설정된다.")
-    void whenLimitGreaterMaximumLimitThenDefaultLimitUsed() {
-        final String page = "5";
-        final String limit = "500";
-        final CustomPageable newPage = PageFactory.createPage(page, limit);
+    @DisplayName("pageSize가 최대 pageSize 보다 크면, 기본 pageSize값으로 설정된다.")
+    void whenpageSizeGreaterMaximumpageSizeThenDefaultpageSizeUsed() {
+        final String pageNumber = "5";
+        final String pageSize = "500";
+        final CustomPageable newPage = PageFactory.createPage(pageNumber, pageSize);
 
         assertNotNull(newPage);
-        assertEquals(Integer.parseInt(page), newPage.getPage());
-        assertEquals(DEFAULT_LIMIT, newPage.getLimit());
+        assertEquals(Integer.parseInt(pageNumber), newPage.getPageNumber());
+        assertEquals(DEFAULT_PAGE_SIZE, newPage.getPageSize());
     }
 }


### PR DESCRIPTION
## 📝 작업 내용

제가 이전 회고 페이징 조회 API에 클라이언트에서 필요한 전체 페이징 개수도 포함 하였어야 하는데 실수로 놓쳤기에 추가하였습니다.

- [X] 회고 조회 시 전체 페이지 개수 추가
- [X] 테스트 작성

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-361)
