### PR TITLE
[DLG-362] 회고 조회 API를 리팩토링한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/web/CursorPagingArgumentResolver.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/web/CursorPagingArgumentResolver.java
@@ -7,8 +7,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import project.dailyge.app.common.annotation.CursorPageable;
-import project.dailyge.app.cursor.Cursor;
-import project.dailyge.app.cursor.CursorFactory;
+import project.dailyge.app.paging.Cursor;
+import project.dailyge.app.paging.CursorFactory;
 
 @Order(2)
 public class CursorPagingArgumentResolver implements HandlerMethodArgumentResolver {

--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/web/OffsetPagingArgumentResolver.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/web/OffsetPagingArgumentResolver.java
@@ -7,8 +7,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import project.dailyge.app.common.annotation.OffsetPageable;
-import project.dailyge.app.page.CustomPageable;
-import project.dailyge.app.page.PageFactory;
+import project.dailyge.app.paging.CustomPageable;
+import project.dailyge.app.paging.PageFactory;
 
 @Order(3)
 public class OffsetPagingArgumentResolver implements HandlerMethodArgumentResolver {

--- a/dailyge-api/src/main/java/project/dailyge/app/core/monthlygoal/application/MonthlyGoalReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/monthlygoal/application/MonthlyGoalReadService.java
@@ -1,7 +1,7 @@
 package project.dailyge.app.core.monthlygoal.application;
 
 import project.dailyge.app.core.common.auth.DailygeUser;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.monthlygoal.MonthlyGoalJpaEntity;
 
 import java.util.List;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/monthlygoal/application/usecase/MonthlyGoalReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/monthlygoal/application/usecase/MonthlyGoalReadUseCase.java
@@ -8,7 +8,7 @@ import project.dailyge.app.core.monthlygoal.application.validator.MonthlyGoalVal
 import static project.dailyge.app.core.monthlygoal.exception.MonthlyGoalCodeAndMessage.MONTHLY_GOAL_NOT_FOUND;
 import project.dailyge.app.core.monthlygoal.exception.MonthlyGoalTypeException;
 import project.dailyge.app.core.monthlygoal.persistence.MonthlyGoalReadDao;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.monthlygoal.MonthlyGoalEntityReadRepository;
 import project.dailyge.entity.monthlygoal.MonthlyGoalJpaEntity;
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/monthlygoal/persistence/MonthlyGoalReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/monthlygoal/persistence/MonthlyGoalReadDao.java
@@ -4,7 +4,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import static java.util.Optional.ofNullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.monthlygoal.MonthlyGoalEntityReadRepository;
 import project.dailyge.entity.monthlygoal.MonthlyGoalJpaEntity;
 import static project.dailyge.entity.monthlygoal.QMonthlyGoalJpaEntity.monthlyGoalJpaEntity;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/monthlygoal/presentation/MonthlyGoalReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/monthlygoal/presentation/MonthlyGoalReadApi.java
@@ -12,7 +12,7 @@ import project.dailyge.app.common.response.ApiResponse;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.monthlygoal.application.MonthlyGoalReadService;
 import project.dailyge.app.core.monthlygoal.presentation.response.MonthlyGoalResponse;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 
 import java.util.List;
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/RetrospectReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/RetrospectReadService.java
@@ -1,7 +1,7 @@
 package project.dailyge.app.core.retrospect.application;
 
 import project.dailyge.app.core.common.auth.DailygeUser;
-import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.paging.CustomPageable;
 import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/RetrospectReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/RetrospectReadService.java
@@ -1,14 +1,12 @@
 package project.dailyge.app.core.retrospect.application;
 
-import java.util.List;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 
 public interface RetrospectReadService {
     RetrospectJpaEntity findById(Long retrospectId);
 
-    List<RetrospectJpaEntity> findRetrospectByPage(DailygeUser dailygeUser, CustomPageable page);
-
-    long findTotalCount(DailygeUser dailygeUser);
+    AsyncPagingResponse<RetrospectJpaEntity> findRetrospectAndTotalCountByPage(DailygeUser dailygeUser, CustomPageable page);
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
@@ -1,14 +1,13 @@
 package project.dailyge.app.core.retrospect.application.usecase;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import project.dailyge.app.common.annotation.ApplicationLayer;
-import project.dailyge.app.common.annotation.OffsetPageable;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.retrospect.application.RetrospectReadService;
 import project.dailyge.app.core.retrospect.exception.RetrospectTypeException;
 import project.dailyge.app.core.retrospect.persistence.RetrospectEntityReadDao;
 import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectEntityReadRepository;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 import static project.dailyge.app.core.retrospect.exception.RetrospectCodeAndMessage.RETROSPECT_NOT_FOUND;
@@ -27,15 +26,10 @@ class RetrospectReadUseCase implements RetrospectReadService {
     }
 
     @Override
-    public List<RetrospectJpaEntity> findRetrospectByPage(
+    public AsyncPagingResponse<RetrospectJpaEntity> findRetrospectAndTotalCountByPage(
         final DailygeUser dailygeUser,
-        final @OffsetPageable CustomPageable page
+        final CustomPageable page
     ) {
-        return retrospectEntityReadDao.findRetrospectByPage(dailygeUser.getId(), page);
-    }
-
-    @Override
-    public long findTotalCount(final DailygeUser dailygeUser) {
-        return retrospectEntityReadDao.findTotalCount(dailygeUser.getId());
+        return retrospectEntityReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getId(), page);
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
@@ -6,7 +6,7 @@ import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.retrospect.application.RetrospectReadService;
 import project.dailyge.app.core.retrospect.exception.RetrospectTypeException;
 import project.dailyge.app.core.retrospect.persistence.RetrospectEntityReadDao;
-import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.paging.CustomPageable;
 import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectEntityReadRepository;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
@@ -3,12 +3,16 @@ package project.dailyge.app.core.retrospect.persistence;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import project.dailyge.app.common.exception.CommonException;
 import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectEntityReadRepository;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 import static java.util.Optional.ofNullable;
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.DATA_ACCESS_EXCEPTION;
 import static project.dailyge.entity.retrospect.QRetrospectJpaEntity.retrospectJpaEntity;
 
 @Repository
@@ -28,14 +32,36 @@ public class RetrospectEntityReadDao implements RetrospectEntityReadRepository {
         );
     }
 
-    public List<RetrospectJpaEntity> findRetrospectByPage(
+    public AsyncPagingResponse<RetrospectJpaEntity> findRetrospectAndTotalCountByPage(
+        final Long userId,
+        final CustomPageable page
+    ) {
+        final CompletableFuture<List<RetrospectJpaEntity>> retrospectsFuture = CompletableFuture.supplyAsync(() ->
+            this.findRetrospectByPage(userId, page)
+        );
+        final CompletableFuture<Long> totalCountFuture = CompletableFuture.supplyAsync(() ->
+            this.findTotalCount(userId)
+        );
+
+        final CompletableFuture<AsyncPagingResponse> asyncPagingResponseFuture = CompletableFuture.allOf(retrospectsFuture, totalCountFuture)
+            .thenApply(ignored -> {
+                final List<RetrospectJpaEntity> retrospects = retrospectsFuture.join();
+                final Long totalCount = totalCountFuture.join();
+                return new AsyncPagingResponse(retrospects, totalCount);
+            }).exceptionally(ex -> {
+                throw CommonException.from(ex.getMessage(), DATA_ACCESS_EXCEPTION);
+            });
+        return asyncPagingResponseFuture.join();
+    }
+
+    private List<RetrospectJpaEntity> findRetrospectByPage(
         final Long userId,
         final CustomPageable page
     ) {
         return jpaQueryFactory.selectFrom(retrospectJpaEntity)
             .where(
                 retrospectJpaEntity.userId.eq(userId)
-                .and(retrospectJpaEntity.deleted.eq(false))
+                    .and(retrospectJpaEntity.deleted.eq(false))
             )
             .orderBy(retrospectJpaEntity.date.desc())
             .offset(page.getOffset())
@@ -43,7 +69,7 @@ public class RetrospectEntityReadDao implements RetrospectEntityReadRepository {
             .fetch();
     }
 
-    public long findTotalCount(final Long userId) {
+    private Long findTotalCount(final Long userId) {
         return jpaQueryFactory.from(retrospectJpaEntity)
             .select(retrospectJpaEntity.id.count())
             .where(

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
@@ -40,10 +40,10 @@ public class RetrospectEntityReadDao implements RetrospectEntityReadRepository {
         final CustomPageable page
     ) {
         final CompletableFuture<List<RetrospectJpaEntity>> retrospectsFuture = CompletableFuture.supplyAsync(() ->
-            this.findRetrospectByPage(userId, page)
+            findRetrospectByPage(userId, page)
         );
         final CompletableFuture<Integer> totalCountFuture = CompletableFuture.supplyAsync(() ->
-            this.findTotalCount(userId)
+            findTotalCount(userId)
         );
 
         final CompletableFuture<AsyncPagingResponse> asyncPagingResponseFuture = CompletableFuture.allOf(retrospectsFuture, totalCountFuture)

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectEntityReadDao.java
@@ -9,7 +9,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 import project.dailyge.app.common.exception.CommonException;
-import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.paging.CustomPageable;
 import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectEntityReadRepository;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
@@ -28,7 +28,7 @@ public class RetrospectReadApi {
         @OffsetPageable final CustomPageable page
     ) {
         final AsyncPagingResponse<RetrospectJpaEntity> retrospectByPage = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
-        final long totalPageCount = page.getTotalPageCount(retrospectByPage.totalCount());
+        final int totalPageCount = page.getTotalPageCount(retrospectByPage.totalCount());
         final RetrospectPageResponse payload = new RetrospectPageResponse(retrospectByPage.data(), totalPageCount);
 
         return ApiResponse.from(OK, payload);

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
@@ -10,7 +10,7 @@ import project.dailyge.app.common.response.ApiResponse;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.retrospect.application.RetrospectReadService;
 import project.dailyge.app.core.retrospect.presentation.response.RetrospectPageResponse;
-import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.paging.CustomPageable;
 import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.OK;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
@@ -1,11 +1,24 @@
 package project.dailyge.app.core.retrospect.presentation.response;
 
 import java.util.List;
+import lombok.Getter;
+import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 
-public record RetrospectPageResponse(
-    List<RetrospectResponse> retrospects,
-    long totalPageCount
-) {
+@Getter
+public class RetrospectPageResponse {
+
+    final List<RetrospectResponse> retrospects;
+    final long totalPageCount;
+
+    public RetrospectPageResponse(
+        final List<RetrospectJpaEntity> retrospects,
+        final long totalPageCount
+    ) {
+        this.retrospects = retrospects.stream()
+            .map(RetrospectResponse::new)
+            .toList();
+        this.totalPageCount = totalPageCount;
+    }
 
     @Override
     public String toString() {

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/response/RetrospectPageResponse.java
@@ -8,11 +8,11 @@ import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 public class RetrospectPageResponse {
 
     final List<RetrospectResponse> retrospects;
-    final long totalPageCount;
+    final int totalPageCount;
 
     public RetrospectPageResponse(
         final List<RetrospectJpaEntity> retrospects,
-        final long totalPageCount
+        final int totalPageCount
     ) {
         this.retrospects = retrospects.stream()
             .map(RetrospectResponse::new)

--- a/dailyge-api/src/main/java/project/dailyge/app/core/weeklygoal/application/WeeklyGoalReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/weeklygoal/application/WeeklyGoalReadService.java
@@ -1,7 +1,7 @@
 package project.dailyge.app.core.weeklygoal.application;
 
 import project.dailyge.app.core.common.auth.DailygeUser;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.weeklygoal.WeeklyGoalJpaEntity;
 
 import java.time.LocalDateTime;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/weeklygoal/application/usecase/WeeklyGoalReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/weeklygoal/application/usecase/WeeklyGoalReadUseCase.java
@@ -5,7 +5,7 @@ import project.dailyge.app.common.annotation.ApplicationLayer;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.weeklygoal.application.WeeklyGoalReadService;
 import project.dailyge.app.core.weeklygoal.persistence.WeeklyGoalReadDao;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.weeklygoal.WeeklyGoalJpaEntity;
 
 import java.time.LocalDateTime;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/weeklygoal/persistence/WeeklyGoalReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/weeklygoal/persistence/WeeklyGoalReadDao.java
@@ -3,7 +3,7 @@ package project.dailyge.app.core.weeklygoal.persistence;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.weeklygoal.WeeklyGoalEntityReadRepository;
 import project.dailyge.entity.weeklygoal.WeeklyGoalJpaEntity;
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/weeklygoal/presentation/WeeklyGoalReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/weeklygoal/presentation/WeeklyGoalReadApi.java
@@ -13,7 +13,7 @@ import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.weeklygoal.application.WeeklyGoalReadService;
 import project.dailyge.app.core.weeklygoal.presentation.validator.WeeklyGoalClientValidator;
 import project.dailyge.app.core.weeklygoal.response.WeeklyGoalResponse;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/dailyge-api/src/test/java/project/dailyge/app/test/monthlygoal/integrationtest/MonthlyGoalReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/monthlygoal/integrationtest/MonthlyGoalReadIntegrationTest.java
@@ -9,8 +9,8 @@ import project.dailyge.app.common.DatabaseTestBase;
 import project.dailyge.app.core.monthlygoal.application.MonthlyGoalReadService;
 import project.dailyge.app.core.monthlygoal.application.MonthlyGoalWriteService;
 import project.dailyge.app.core.monthlygoal.application.command.MonthlyGoalCreateCommand;
-import project.dailyge.app.cursor.Cursor;
-import static project.dailyge.app.cursor.Cursor.createCursor;
+import project.dailyge.app.paging.Cursor;
+import static project.dailyge.app.paging.Cursor.createCursor;
 import project.dailyge.entity.monthlygoal.MonthlyGoalJpaEntity;
 
 import java.time.LocalDate;

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
@@ -11,6 +11,7 @@ import project.dailyge.app.core.retrospect.application.RetrospectReadService;
 import project.dailyge.app.core.retrospect.application.RetrospectWriteService;
 import project.dailyge.app.core.retrospect.application.command.RetrospectCreateCommand;
 import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,41 +38,46 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
     @DisplayName("회고 조회 시 정상적으로 반환한다.")
     void whenFindRetrospectThenResultShouldBeCorrectly() {
         final CustomPageable page = CustomPageable.createPage(1, 10);
-        final List<RetrospectJpaEntity> findRetrospects = retrospectReadService.findRetrospectByPage(dailygeUser, page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
+        final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
+        final int totalCount = asyncPagingResponse.totalCount();
 
         assertEquals(10, findRetrospects.size());
+        assertEquals(10, totalCount);
     }
 
     @Test
     @DisplayName("회고 조회 시 페이징을 최신 데이터 순으로 반환한다.")
     void whenFindRetrospectThenResultShouldBeRecentDatePagingReturned() {
         final CustomPageable page = CustomPageable.createPage(3, 1);
-        final List<RetrospectJpaEntity> findRetrospects = retrospectReadService.findRetrospectByPage(dailygeUser, page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
 
+        final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
         assertEquals(1, findRetrospects.size());
 
         final RetrospectJpaEntity findRetrospect = findRetrospects.get(0);
         assertEquals(8, findRetrospect.getId());
     }
 
-
     @Test
     @DisplayName("페이지 이후의 데이터가 없다면, 빈 리스트을 반환한다.")
     void whenNoDataAfterThePageThenResultShouldBeEmptyList() {
         final CustomPageable page = CustomPageable.createPage(2, 10);
-        final List<RetrospectJpaEntity> findRetrospects = retrospectReadService.findRetrospectByPage(dailygeUser, page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
+        final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
 
         assertTrue(findRetrospects.isEmpty());
     }
 
-
     @Test
     @DisplayName("자신의 회고 전체 개수만 반환한다.")
     void whenFindTotalCountThenResultShouldBeMyTotalRetrospectCount() {
+        final CustomPageable page = CustomPageable.createPage(1, 10);
         final RetrospectCreateCommand createCommand = new RetrospectCreateCommand("회고 제목", "회고 내용", now.atTime(0, 0, 0, 0), false);
         retrospectWriteService.save(invalidUser, createCommand);
 
-        final long totalCount = retrospectReadService.findTotalCount(dailygeUser);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
+        final int totalCount = asyncPagingResponse.totalCount();
 
         assertEquals(10, totalCount);
     }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
@@ -52,8 +52,7 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
     @DisplayName("회고 조회 시 정상적으로 반환한다.")
     void whenFindRetrospectThenResultShouldBeCorrectly() {
         final CustomPageable page = CustomPageable.createPage(1, 10);
-        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser,
-            page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
         final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
         final int totalCount = asyncPagingResponse.totalCount();
 
@@ -65,8 +64,7 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
     @DisplayName("회고 조회 시 페이징을 최신 데이터 순으로 반환한다.")
     void whenFindRetrospectThenResultShouldBeRecentDatePagingReturned() {
         final CustomPageable page = CustomPageable.createPage(3, 1);
-        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser,
-            page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
 
         final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
         assertEquals(1, findRetrospects.size());
@@ -79,8 +77,7 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
     @DisplayName("페이지 이후의 데이터가 없다면, 빈 리스트을 반환한다.")
     void whenNoDataAfterThePageThenResultShouldBeEmptyList() {
         final CustomPageable page = CustomPageable.createPage(2, 10);
-        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser,
-            page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
         final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
 
         assertTrue(findRetrospects.isEmpty());
@@ -93,8 +90,7 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
         final RetrospectCreateCommand createCommand = new RetrospectCreateCommand("회고 제목", "회고 내용", now.atTime(0, 0, 0, 0), false);
         retrospectWriteService.save(invalidUser, createCommand);
 
-        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser,
-            page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
         final int totalCount = asyncPagingResponse.totalCount();
 
         assertEquals(10, totalCount);

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
@@ -10,7 +10,7 @@ import project.dailyge.app.common.DatabaseTestBase;
 import project.dailyge.app.core.retrospect.application.RetrospectReadService;
 import project.dailyge.app.core.retrospect.application.RetrospectWriteService;
 import project.dailyge.app.core.retrospect.application.command.RetrospectCreateCommand;
-import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.paging.CustomPageable;
 import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
@@ -52,7 +52,8 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
     @DisplayName("회고 조회 시 정상적으로 반환한다.")
     void whenFindRetrospectThenResultShouldBeCorrectly() {
         final CustomPageable page = CustomPageable.createPage(1, 10);
-        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser,
+            page);
         final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
         final int totalCount = asyncPagingResponse.totalCount();
 
@@ -64,7 +65,8 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
     @DisplayName("회고 조회 시 페이징을 최신 데이터 순으로 반환한다.")
     void whenFindRetrospectThenResultShouldBeRecentDatePagingReturned() {
         final CustomPageable page = CustomPageable.createPage(3, 1);
-        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser,
+            page);
 
         final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
         assertEquals(1, findRetrospects.size());
@@ -77,7 +79,8 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
     @DisplayName("페이지 이후의 데이터가 없다면, 빈 리스트을 반환한다.")
     void whenNoDataAfterThePageThenResultShouldBeEmptyList() {
         final CustomPageable page = CustomPageable.createPage(2, 10);
-        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser,
+            page);
         final List<RetrospectJpaEntity> findRetrospects = asyncPagingResponse.data();
 
         assertTrue(findRetrospects.isEmpty());
@@ -90,7 +93,8 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
         final RetrospectCreateCommand createCommand = new RetrospectCreateCommand("회고 제목", "회고 내용", now.atTime(0, 0, 0, 0), false);
         retrospectWriteService.save(invalidUser, createCommand);
 
-        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser, page);
+        final AsyncPagingResponse<RetrospectJpaEntity> asyncPagingResponse = retrospectReadService.findRetrospectAndTotalCountByPage(dailygeUser,
+            page);
         final int totalCount = asyncPagingResponse.totalCount();
 
         assertEquals(10, totalCount);
@@ -105,7 +109,8 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
         final RetrospectEntityReadDao retrospectEntityReadDao = new RetrospectEntityReadDao(mockJPAQueryFactory, mockJdbcTemplate);
 
         when(mockJdbcTemplate.queryForObject(anyString(), eq(Integer.class), anyLong()))
-            .thenThrow(new DataAccessException("Query execution exception"){});
+            .thenThrow(new DataAccessException("Query execution exception") {
+            });
 
         assertThatThrownBy(() -> retrospectEntityReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getUserId(), page))
             .isInstanceOf(CompletionException.class)
@@ -122,7 +127,8 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
         final RetrospectEntityReadDao retrospectEntityReadDao = new RetrospectEntityReadDao(mockJPAQueryFactory, mockJdbcTemplate);
 
         when(mockJPAQueryFactory.selectFrom(any()))
-            .thenThrow(new DataAccessException("Query execution exception"){});
+            .thenThrow(new DataAccessException("Query execution exception") {
+            });
 
         assertThatThrownBy(() -> retrospectEntityReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getUserId(), page))
             .isInstanceOf(CompletionException.class)

--- a/dailyge-api/src/test/java/project/dailyge/app/test/weeklygoal/integrationtest/WeeklyGoalReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/weeklygoal/integrationtest/WeeklyGoalReadIntegrationTest.java
@@ -8,7 +8,7 @@ import project.dailyge.app.common.DatabaseTestBase;
 import project.dailyge.app.core.weeklygoal.application.WeeklyGoalReadService;
 import project.dailyge.app.core.weeklygoal.application.WeeklyGoalWriteService;
 import project.dailyge.app.core.weeklygoal.application.command.WeeklyGoalCreateCommand;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.weeklygoal.WeeklyGoalJpaEntity;
 
 import java.time.DayOfWeek;
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static project.dailyge.app.cursor.Cursor.createCursor;
+import static project.dailyge.app.paging.Cursor.createCursor;
 
 @DisplayName("[IntegrationTest] 주간 목표 조회 통합 테스트")
 class WeeklyGoalReadIntegrationTest extends DatabaseTestBase {

--- a/support/src/main/java/project/dailyge/app/page/CustomPageable.java
+++ b/support/src/main/java/project/dailyge/app/page/CustomPageable.java
@@ -27,7 +27,7 @@ public class CustomPageable {
         return (pageNumber - 1) * pageSize;
     }
 
-    public long getTotalPageCount(final long totalCount) {
+    public int getTotalPageCount(final int totalCount) {
         return (totalCount - 1) / pageSize + 1;
     }
 

--- a/support/src/main/java/project/dailyge/app/paging/Cursor.java
+++ b/support/src/main/java/project/dailyge/app/paging/Cursor.java
@@ -1,4 +1,4 @@
-package project.dailyge.app.cursor;
+package project.dailyge.app.paging;
 
 import lombok.Getter;
 

--- a/support/src/main/java/project/dailyge/app/paging/CursorFactory.java
+++ b/support/src/main/java/project/dailyge/app/paging/CursorFactory.java
@@ -1,4 +1,4 @@
-package project.dailyge.app.cursor;
+package project.dailyge.app.paging;
 
 public final class CursorFactory {
 

--- a/support/src/main/java/project/dailyge/app/paging/CustomPageable.java
+++ b/support/src/main/java/project/dailyge/app/paging/CustomPageable.java
@@ -1,4 +1,4 @@
-package project.dailyge.app.page;
+package project.dailyge.app.paging;
 
 import lombok.Getter;
 

--- a/support/src/main/java/project/dailyge/app/paging/PageFactory.java
+++ b/support/src/main/java/project/dailyge/app/paging/PageFactory.java
@@ -1,4 +1,4 @@
-package project.dailyge.app.page;
+package project.dailyge.app.paging;
 
 public final class PageFactory {
 

--- a/support/src/main/java/project/dailyge/app/response/AsyncPagingResponse.java
+++ b/support/src/main/java/project/dailyge/app/response/AsyncPagingResponse.java
@@ -1,0 +1,10 @@
+package project.dailyge.app.response;
+
+import java.util.List;
+
+public record AsyncPagingResponse<T>(
+    List<T> data,
+    Long totalCount
+) {
+
+}

--- a/support/src/main/java/project/dailyge/app/response/AsyncPagingResponse.java
+++ b/support/src/main/java/project/dailyge/app/response/AsyncPagingResponse.java
@@ -6,5 +6,4 @@ public record AsyncPagingResponse<T>(
     List<T> data,
     int totalCount
 ) {
-
 }

--- a/support/src/main/java/project/dailyge/app/response/AsyncPagingResponse.java
+++ b/support/src/main/java/project/dailyge/app/response/AsyncPagingResponse.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public record AsyncPagingResponse<T>(
     List<T> data,
-    Long totalCount
+    int totalCount
 ) {
 
 }

--- a/support/src/test/java/project/dailyge/support/test/cursor/CursorFactoryUnitTest.java
+++ b/support/src/test/java/project/dailyge/support/test/cursor/CursorFactoryUnitTest.java
@@ -5,8 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import project.dailyge.app.cursor.Cursor;
-import project.dailyge.app.cursor.CursorFactory;
+import project.dailyge.app.paging.Cursor;
+import project.dailyge.app.paging.CursorFactory;
 
 @DisplayName("[UnitTest] CursorFactory 단위 테스트")
 class CursorFactoryUnitTest {

--- a/support/src/test/java/project/dailyge/support/test/cursor/CursorUnitTest.java
+++ b/support/src/test/java/project/dailyge/support/test/cursor/CursorUnitTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import project.dailyge.app.cursor.Cursor;
+import project.dailyge.app.paging.Cursor;
 
 @DisplayName("[UnitTest] Cursor 단위 테스트")
 class CursorUnitTest {

--- a/support/src/test/java/project/dailyge/support/test/page/CustomPageableUnitTest.java
+++ b/support/src/test/java/project/dailyge/support/test/page/CustomPageableUnitTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import project.dailyge.app.page.CustomPageable;
+import project.dailyge.app.paging.CustomPageable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 

--- a/support/src/test/java/project/dailyge/support/test/page/PageFactoryUnitTest.java
+++ b/support/src/test/java/project/dailyge/support/test/page/PageFactoryUnitTest.java
@@ -2,8 +2,8 @@ package project.dailyge.support.test.page;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import project.dailyge.app.page.CustomPageable;
-import project.dailyge.app.page.PageFactory;
+import project.dailyge.app.paging.CustomPageable;
+import project.dailyge.app.paging.PageFactory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 


### PR DESCRIPTION
## 📝 작업 내용

이전 [PR](#213 ) 이 생각보다 길어져 새로운 PR에서 코드 리뷰 사항들을 모두 반영하기 위해 작성하였습니다.

- [X] 회고 페이징 비동기 처리 로직을 Controller -> Repository로 리팩토링
- [X] 회고 Count 쿼리 QueryDSL에서 -> JdbcTemplate로 리팩토링

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-362)


[DLG-361]: https://jungjunwoojun.atlassian.net/browse/DLG-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ