### PR TITLE
[DLG-365] 반복 일정 규칙 테이블을 설계하고 엔티티를 매핑한다.

### DIFF
--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -23,21 +23,22 @@ CREATE TABLE IF NOT EXISTS user_sequence
 DROP TABLE IF EXISTS tasks;
 CREATE TABLE IF NOT EXISTS tasks
 (
-    id               BIGINT AUTO_INCREMENT PRIMARY KEY    NOT NULL COMMENT '할 일 ID',
-    user_id          BIGINT                               NOT NULL COMMENT '사용자 ID',
-    title            VARCHAR(150)                         NOT NULL COMMENT '제목',
-    content          VARCHAR(2500)                        NOT NULL COMMENT '내용',
-    `month`          INT                                  NOT NULL COMMENT '월',
-    `year`           INT                                  NOT NULL COMMENT '년',
-    `date`           DATE                                 NOT NULL COMMENT '날짜',
-    status           ENUM ('TODO', 'IN_PROGRESS', 'DONE') NOT NULL COMMENT '할 일 상태',
-    color            varchar(255)                         NOT NULL COMMENT '할 일 색상',
-    monthly_task_id  BIGINT                               NOT NULL COMMENT '월간 일정',
-    created_at       TIMESTAMP                            NOT NULL COMMENT '생성일',
-    created_by       BIGINT                               NULL COMMENT '생성한 사람',
-    last_modified_at TIMESTAMP                            NULL COMMENT '최종 수정일',
-    last_modified_by BIGINT                               NULL COMMENT '최종 수정한 사람',
-    deleted          BIT                                  NOT NULL COMMENT '삭제 유무'
+    id                  BIGINT AUTO_INCREMENT PRIMARY KEY    NOT NULL COMMENT '할 일 ID',
+    user_id             BIGINT                               NOT NULL COMMENT '사용자 ID',
+    title               VARCHAR(150)                         NOT NULL COMMENT '제목',
+    content             VARCHAR(2500)                        NOT NULL COMMENT '내용',
+    `month`             INT                                  NOT NULL COMMENT '월',
+    `year`              INT                                  NOT NULL COMMENT '년',
+    `date`              DATE                                 NOT NULL COMMENT '날짜',
+    status              ENUM ('TODO', 'IN_PROGRESS', 'DONE') NOT NULL COMMENT '할 일 상태',
+    color               varchar(255)                         NOT NULL COMMENT '할 일 색상',
+    monthly_task_id     BIGINT                               NOT NULL COMMENT '월간 일정',
+    task_recurrence_id  BIGINT                               NULL COMMENT '반복 일정 규칙 ID',
+    created_at          TIMESTAMP                            NOT NULL COMMENT '생성일',
+    created_by          BIGINT                               NULL COMMENT '생성한 사람',
+    last_modified_at    TIMESTAMP                            NULL COMMENT '최종 수정일',
+    last_modified_by    BIGINT                               NULL COMMENT '최종 수정한 사람',
+    deleted             BIT                                  NOT NULL COMMENT '삭제 유무'
 ) engine 'InnoDB' COMMENT '할 일';
 
 DROP TABLE IF EXISTS users;
@@ -233,4 +234,4 @@ CREATE TABLE IF NOT EXISTS task_recurrences
     last_modified_at TIMESTAMP                         NOT NULL COMMENT '최종 수정일',
     last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
-)
+) engine = 'InnoDB' COMMENT '반복 일정 규칙';

--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -218,3 +218,19 @@ CREATE TABLE IF NOT EXISTS weekly_goals
     last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
     deleted          BIT                               NOT NULL COMMENT '삭제 유무'
 ) engine = 'InnoDB' COMMENT '주간 목표';
+
+DROP TABLE IF EXISTS task_recurrences;
+CREATE TABLE IF NOT EXISTS task_recurrences
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '주간 목표 ID',
+    cron_expression  VARCHAR(50)                       NOT NULL COMMENT '반복 일정 cron 표현식',
+    title            VARCHAR(50)                       NOT NULL COMMENT '제목',
+    content          VARCHAR(1500)                     NOT NULL COMMENT '내용',
+    start_date       TIMESTAMP                         NOT NULL COMMENT '시작 날짜',
+    end_date         TIMESTAMP                         NOT NULL COMMENT '끝나는 날짜',
+    created_at       TIMESTAMP                         NOT NULL COMMENT '생성일',
+    created_by       BIGINT                            NULL COMMENT '생성한 사람',
+    last_modified_at TIMESTAMP                         NOT NULL COMMENT '최종 수정일',
+    last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
+    deleted          BIT                               NOT NULL COMMENT '삭제 유무'
+)

--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -222,7 +222,7 @@ CREATE TABLE IF NOT EXISTS weekly_goals
 
 DROP TABLE IF EXISTS task_recurrences;
 CREATE TABLE IF NOT EXISTS task_recurrences (
-    id                      BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '주간 목표 ID',
+    id                      BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '반복 일정 ID',
     recurrence_type         ENUM('WEEKLY', 'DAILY', 'WEEKDAY', 'MONTHLY', 'CUSTOM') NOT NULL COMMENT '반복 일정 종류',
     date_pattern            JSON NOT NULL COMMENT '반복 날짜 패턴 ([1,2,3,4] or [1,31])',
     title                   VARCHAR(50) NOT NULL COMMENT '제목',

--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -221,17 +221,19 @@ CREATE TABLE IF NOT EXISTS weekly_goals
 ) engine = 'InnoDB' COMMENT '주간 목표';
 
 DROP TABLE IF EXISTS task_recurrences;
-CREATE TABLE IF NOT EXISTS task_recurrences
-(
-    id               BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '주간 목표 ID',
-    cron_expression  VARCHAR(50)                       NOT NULL COMMENT '반복 일정 cron 표현식',
-    title            VARCHAR(50)                       NOT NULL COMMENT '제목',
-    content          VARCHAR(1500)                     NOT NULL COMMENT '내용',
-    start_date       TIMESTAMP                         NOT NULL COMMENT '시작 날짜',
-    end_date         TIMESTAMP                         NOT NULL COMMENT '끝나는 날짜',
-    created_at       TIMESTAMP                         NOT NULL COMMENT '생성일',
-    created_by       BIGINT                            NULL COMMENT '생성한 사람',
-    last_modified_at TIMESTAMP                         NOT NULL COMMENT '최종 수정일',
-    last_modified_by BIGINT                            NULL COMMENT '최종 수정한 사람',
-    deleted          BIT                               NOT NULL COMMENT '삭제 유무'
-) engine = 'InnoDB' COMMENT '반복 일정 규칙';
+CREATE TABLE IF NOT EXISTS task_recurrences (
+    id                      BIGINT AUTO_INCREMENT PRIMARY KEY NOT NULL COMMENT '주간 목표 ID',
+    recurrence_type         ENUM('WEEKLY', 'DAILY', 'WEEKDAY', 'MONTHLY', 'CUSTOM') NOT NULL COMMENT '반복 일정 종류',
+    date_pattern            JSON NOT NULL COMMENT '반복 날짜 패턴 ([1,2,3,4] or [1,31])',
+    title                   VARCHAR(50) NOT NULL COMMENT '제목',
+    content                 VARCHAR(1500) NOT NULL COMMENT '내용',
+    start_date              TIMESTAMP NOT NULL COMMENT '시작 날짜',
+    end_date                TIMESTAMP NOT NULL COMMENT '끝나는 날짜',
+    created_at              TIMESTAMP NOT NULL COMMENT '생성일',
+    created_by              BIGINT NULL COMMENT '생성한 사람',
+    last_modified_at        TIMESTAMP NOT NULL COMMENT '최종 수정일',
+    last_modified_by        BIGINT NULL COMMENT '최종 수정한 사람',
+    deleted BIT NOT NULL    COMMENT '삭제 유무'
+) engine = 'InnoDB'
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_general_ci COMMENT '반복 일정 규칙';

--- a/storage/rdb/src/main/java/project/dailyge/entity/task/RecurrenceType.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/task/RecurrenceType.java
@@ -1,0 +1,9 @@
+package project.dailyge.entity.task;
+
+public enum RecurrenceType {
+    DAILY,
+    WEEKDAY,
+    WEEKLY,
+    MONTHLY,
+    CUSTOM
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/task/TaskJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/task/TaskJpaEntity.java
@@ -62,6 +62,9 @@ public class TaskJpaEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private TaskColor color;
 
+    @Column(name = "task_recurrence_id")
+    private Long taskRecurrenceId;
+
     public TaskJpaEntity(
         final String title,
         final String content,
@@ -81,6 +84,19 @@ public class TaskJpaEntity extends BaseEntity {
         final Long monthlyTaskId,
         final Long userId
     ) {
+        this(title, content, date, status, color, monthlyTaskId, userId, null);
+    }
+
+    public TaskJpaEntity(
+        final String title,
+        final String content,
+        final LocalDate date,
+        final TaskStatus status,
+        final TaskColor color,
+        final Long monthlyTaskId,
+        final Long userId,
+        final Long taskRecurrenceId
+    ) {
         validate(title, content, date);
         this.title = title;
         this.content = content;
@@ -93,6 +109,7 @@ public class TaskJpaEntity extends BaseEntity {
         this.userId = userId;
         this.createdBy = userId;
         this.createdAt = LocalDateTime.now();
+        this.taskRecurrenceId = taskRecurrenceId;
     }
 
     @Builder

--- a/storage/rdb/src/main/java/project/dailyge/entity/task/TaskRecurrenceJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/task/TaskRecurrenceJpaEntity.java
@@ -10,9 +10,12 @@ import lombok.NoArgsConstructor;
 import project.dailyge.entity.BaseEntity;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static lombok.AccessLevel.PROTECTED;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
 @Entity(name = "task_recurrences")
 public class TaskRecurrenceJpaEntity extends BaseEntity {
 
@@ -49,5 +52,22 @@ public class TaskRecurrenceJpaEntity extends BaseEntity {
         this.content = content;
         this.startDate = startDate;
         this.endDate = endDate;
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof TaskRecurrenceJpaEntity that)) {
+            return false;
+        }
+        ;
+        return Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/storage/rdb/src/main/java/project/dailyge/entity/task/TaskRecurrenceJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/task/TaskRecurrenceJpaEntity.java
@@ -1,0 +1,53 @@
+package project.dailyge.entity.task;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.dailyge.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "task_recurrences")
+public class TaskRecurrenceJpaEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "cron_expression")
+    private String cronExpression;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "start_date")
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date")
+    private LocalDateTime endDate;
+
+    public TaskRecurrenceJpaEntity(
+        final Long id,
+        final String cronExpression,
+        final String title,
+        final String content,
+        final LocalDateTime startDate,
+        final LocalDateTime endDate
+    ) {
+        this.id = id;
+        this.cronExpression = cronExpression;
+        this.title = title;
+        this.content = content;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+}

--- a/storage/rdb/src/main/java/project/dailyge/entity/task/TaskRecurrenceJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/task/TaskRecurrenceJpaEntity.java
@@ -62,7 +62,6 @@ public class TaskRecurrenceJpaEntity extends BaseEntity {
         if (!(object instanceof TaskRecurrenceJpaEntity that)) {
             return false;
         }
-        ;
         return Objects.equals(getId(), that.getId());
     }
 

--- a/storage/rdb/src/main/java/project/dailyge/entity/task/TaskRecurrenceJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/task/TaskRecurrenceJpaEntity.java
@@ -2,14 +2,19 @@ package project.dailyge.entity.task;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import project.dailyge.entity.BaseEntity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 
 import static lombok.AccessLevel.PROTECTED;
@@ -23,8 +28,13 @@ public class TaskRecurrenceJpaEntity extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "cron_expression")
-    private String cronExpression;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recurrence_type")
+    private RecurrenceType recurrenceType;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "date_pattern", columnDefinition = "json")
+    private List<Integer> datePattern;
 
     @Column(name = "title")
     private String title;
@@ -40,14 +50,16 @@ public class TaskRecurrenceJpaEntity extends BaseEntity {
 
     public TaskRecurrenceJpaEntity(
         final Long id,
-        final String cronExpression,
+        final RecurrenceType recurrenceType,
+        final List<Integer> datePattern,
         final String title,
         final String content,
         final LocalDateTime startDate,
         final LocalDateTime endDate
     ) {
         this.id = id;
-        this.cronExpression = cronExpression;
+        this.recurrenceType = recurrenceType;
+        this.datePattern = datePattern;
         this.title = title;
         this.content = content;
         this.startDate = startDate;

--- a/storage/rdb/src/test/java/project/dailyge/entity/test/task/TaskRecurrenceJpaEntityUnitTest.java
+++ b/storage/rdb/src/test/java/project/dailyge/entity/test/task/TaskRecurrenceJpaEntityUnitTest.java
@@ -1,0 +1,114 @@
+package project.dailyge.entity.test.task;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import project.dailyge.entity.task.TaskRecurrenceJpaEntity;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@DisplayName("[UnitTest] 반복 일정 엔티티 테스트")
+class TaskRecurrenceJpaEntityUnitTest {
+
+    private TaskRecurrenceJpaEntity taskRecurrence;
+
+    @BeforeEach
+    void setUp() {
+        final LocalDateTime now = LocalDateTime.now();
+        taskRecurrence = new TaskRecurrenceJpaEntity(
+            1L,
+            "0 0 1,15 * *",
+            "수영",
+            "자유형 배우기",
+            now,
+            now.plusMonths(3)
+        );
+    }
+
+    @Test
+    @DisplayName("올바른 인자가 들어오면 TaskRecurrenceJpaEntity가 생성된다.")
+    void whenValidArgumentsThenTaskRecurrenceJpaEntityShouldBeCreated() {
+        final LocalDateTime now = LocalDateTime.now();
+        final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
+            1L,
+            "0 0 1,15 * *",
+            "수영",
+            "자유형 배우기",
+            now,
+            now.plusMonths(3)
+        );
+        assertAll(
+            () -> assertThat(newTaskRecurrence.getId()).isEqualTo(1L),
+            () -> assertThat(newTaskRecurrence.getTitle()).isEqualTo("수영"),
+            () -> assertThat(newTaskRecurrence.getContent()).isEqualTo("자유형 배우기"),
+            () -> assertThat(newTaskRecurrence.getCronExpression()).isEqualTo("0 0 1,15 * *"),
+            () -> assertThat(newTaskRecurrence.getStartDate()).isEqualTo(now),
+            () -> assertThat(newTaskRecurrence.getEndDate()).isEqualTo(now.plusMonths(3))
+        );
+    }
+
+    @Test
+    @DisplayName("id가 동일하면 equals 반환 값이 True이다.")
+    void whenIdIsSameThenEqualsShouldReturnTrue() {
+        final LocalDateTime now = LocalDateTime.now();
+        final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
+            1L,
+            "0 0 1,15 * *",
+            "수영",
+            "자유형 배우기",
+            now,
+            now.plusMonths(3)
+        );
+        assertEquals(taskRecurrence, newTaskRecurrence);
+    }
+
+    @Test
+    @DisplayName("id가 동일하지 않으면 equals 반환 값이 False이다.")
+    void whenIdIsNotSameThenEqualsShouldReturnFalse() {
+        final LocalDateTime now = LocalDateTime.now();
+        final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
+            2L,
+            "0 0 1,15 * *",
+            "수영",
+            "자유형 배우기",
+            now,
+            now.plusMonths(3)
+        );
+        assertNotEquals(taskRecurrence, newTaskRecurrence);
+    }
+
+    @Test
+    @DisplayName("id가 동일하면 해시코드가 동일하다.")
+    void whenIdIsSameThenHashCodeShouldBeSame() {
+        final LocalDateTime now = LocalDateTime.now();
+        final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
+            1L,
+            "0 0 1,15 * *",
+            "수영",
+            "자유형 배우기",
+            now,
+            now.plusMonths(3)
+        );
+        assertEquals(taskRecurrence.hashCode(), newTaskRecurrence.hashCode());
+    }
+
+    @Test
+    @DisplayName("id가 동일하지 않으면 해시코드 값이 동일하지 않다.")
+    void whenIdIsNotSameThenHashCodeShouldNotBeSame() {
+        final LocalDateTime now = LocalDateTime.now();
+        final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
+            2L,
+            "0 0 1,15 * *",
+            "수영",
+            "자유형 배우기",
+            now,
+            now.plusMonths(3)
+        );
+        assertNotEquals(taskRecurrence.hashCode(), newTaskRecurrence.hashCode());
+    }
+}

--- a/storage/rdb/src/test/java/project/dailyge/entity/test/task/TaskRecurrenceJpaEntityUnitTest.java
+++ b/storage/rdb/src/test/java/project/dailyge/entity/test/task/TaskRecurrenceJpaEntityUnitTest.java
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.Test;
 import project.dailyge.entity.task.TaskRecurrenceJpaEntity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static project.dailyge.entity.task.RecurrenceType.WEEKLY;
 
 @DisplayName("[UnitTest] 반복 일정 엔티티 테스트")
 class TaskRecurrenceJpaEntityUnitTest {
@@ -22,7 +24,8 @@ class TaskRecurrenceJpaEntityUnitTest {
         final LocalDateTime now = LocalDateTime.now();
         taskRecurrence = new TaskRecurrenceJpaEntity(
             1L,
-            "0 0 1,15 * *",
+            WEEKLY,
+            List.of(1),
             "수영",
             "자유형 배우기",
             now,
@@ -36,7 +39,8 @@ class TaskRecurrenceJpaEntityUnitTest {
         final LocalDateTime now = LocalDateTime.now();
         final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
             1L,
-            "0 0 1,15 * *",
+            WEEKLY,
+            List.of(1),
             "수영",
             "자유형 배우기",
             now,
@@ -46,7 +50,8 @@ class TaskRecurrenceJpaEntityUnitTest {
             () -> assertThat(newTaskRecurrence.getId()).isEqualTo(1L),
             () -> assertThat(newTaskRecurrence.getTitle()).isEqualTo("수영"),
             () -> assertThat(newTaskRecurrence.getContent()).isEqualTo("자유형 배우기"),
-            () -> assertThat(newTaskRecurrence.getCronExpression()).isEqualTo("0 0 1,15 * *"),
+            () -> assertThat(newTaskRecurrence.getDatePattern()).isEqualTo(List.of(1)),
+            () -> assertThat(newTaskRecurrence.getRecurrenceType()).isEqualTo(WEEKLY),
             () -> assertThat(newTaskRecurrence.getStartDate()).isEqualTo(now),
             () -> assertThat(newTaskRecurrence.getEndDate()).isEqualTo(now.plusMonths(3))
         );
@@ -58,7 +63,8 @@ class TaskRecurrenceJpaEntityUnitTest {
         final LocalDateTime now = LocalDateTime.now();
         final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
             1L,
-            "0 0 1,15 * *",
+            WEEKLY,
+            List.of(1),
             "수영",
             "자유형 배우기",
             now,
@@ -73,7 +79,8 @@ class TaskRecurrenceJpaEntityUnitTest {
         final LocalDateTime now = LocalDateTime.now();
         final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
             2L,
-            "0 0 1,15 * *",
+            WEEKLY,
+            List.of(1),
             "수영",
             "자유형 배우기",
             now,
@@ -88,7 +95,8 @@ class TaskRecurrenceJpaEntityUnitTest {
         final LocalDateTime now = LocalDateTime.now();
         final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
             1L,
-            "0 0 1,15 * *",
+            WEEKLY,
+            List.of(1),
             "수영",
             "자유형 배우기",
             now,
@@ -103,7 +111,8 @@ class TaskRecurrenceJpaEntityUnitTest {
         final LocalDateTime now = LocalDateTime.now();
         final TaskRecurrenceJpaEntity newTaskRecurrence = new TaskRecurrenceJpaEntity(
             2L,
-            "0 0 1,15 * *",
+            WEEKLY,
+            List.of(1),
             "수영",
             "자유형 배우기",
             now,


### PR DESCRIPTION
## 📝 작업 내용

반복 일정 규칙 테이블을 설계하고 엔티티를 매핑합니다. 이러한 설계의 경우 추후에 Tasks 테이블 컬럼에 반복 일정 규칙에 대한 id를 포함시켜야 합니다.

- [X] 반복 일정 규칙 테이블 추가
- [X] 반복 일정 규칙 엔티티 매핑
- [x] 엔티티 단위테스트 작성
 
<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-365)
