### PR TITLE
[DLG-367] 회고 조회 시, 정렬 기준을 추가한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/application/usecase/RetrospectReadUseCase.java
@@ -5,7 +5,7 @@ import project.dailyge.app.common.annotation.ApplicationLayer;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.retrospect.application.RetrospectReadService;
 import project.dailyge.app.core.retrospect.exception.RetrospectTypeException;
-import project.dailyge.app.core.retrospect.persistence.RetrospectEntityReadDao;
+import project.dailyge.app.core.retrospect.persistence.RetrospectReadDao;
 import project.dailyge.app.paging.CustomPageable;
 import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectEntityReadRepository;
@@ -17,7 +17,7 @@ import static project.dailyge.app.core.retrospect.exception.RetrospectCodeAndMes
 class RetrospectReadUseCase implements RetrospectReadService {
 
     private final RetrospectEntityReadRepository retrospectEntityReadRepository;
-    private final RetrospectEntityReadDao retrospectEntityReadDao;
+    private final RetrospectReadDao retrospectReadDao;
 
     @Override
     public RetrospectJpaEntity findById(final Long retrospectId) {
@@ -30,6 +30,6 @@ class RetrospectReadUseCase implements RetrospectReadService {
         final DailygeUser dailygeUser,
         final CustomPageable page
     ) {
-        return retrospectEntityReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getId(), page);
+        return retrospectReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getId(), page);
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectReadDao.java
@@ -19,7 +19,7 @@ import static project.dailyge.entity.retrospect.QRetrospectJpaEntity.retrospectJ
 
 @Repository
 @RequiredArgsConstructor
-public class RetrospectEntityReadDao implements RetrospectEntityReadRepository {
+public class RetrospectReadDao implements RetrospectEntityReadRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
     private final JdbcTemplate jdbcTemplate;
@@ -66,7 +66,10 @@ public class RetrospectEntityReadDao implements RetrospectEntityReadRepository {
                 retrospectJpaEntity.userId.eq(userId)
                     .and(retrospectJpaEntity.deleted.eq(false))
             )
-            .orderBy(retrospectJpaEntity.date.desc())
+            .orderBy(
+                retrospectJpaEntity.date.desc(),
+                retrospectJpaEntity.id.desc()
+            )
             .offset(page.getOffset())
             .limit(page.getPageSize())
             .fetch();

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectWriteDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/persistence/RetrospectWriteDao.java
@@ -8,7 +8,7 @@ import project.dailyge.entity.retrospect.RetrospectJpaEntity;
 
 @Repository
 @RequiredArgsConstructor
-class RetrospectEntityWriteDao implements RetrospectEntityWriteRepository {
+class RetrospectWriteDao implements RetrospectEntityWriteRepository {
 
     private final EntityManager entityManager;
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectCreateApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectCreateApi.java
@@ -22,7 +22,7 @@ public class RetrospectCreateApi {
     private final RetrospectWriteService retrospectWriteService;
 
     @PostMapping
-    public ApiResponse<RetrospectCreateResponse> create(
+    public ApiResponse<RetrospectCreateResponse> createRetrospect(
         @LoginUser final DailygeUser dailygeUser,
         @Valid @RequestBody final RetrospectCreateRequest request
     ) {

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectDeleteApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectDeleteApi.java
@@ -19,7 +19,7 @@ public class RetrospectDeleteApi {
     private final RetrospectWriteService retrospectWriteService;
 
     @DeleteMapping(path = "/{retrospectId}")
-    public ApiResponse<Void> delete(
+    public ApiResponse<Void> deleteRetrospectById(
         @LoginUser final DailygeUser dailygeUser,
         @PathVariable(name = "retrospectId") final Long retrospectId
     ) {

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectReadApi.java
@@ -23,7 +23,7 @@ public class RetrospectReadApi {
     private final RetrospectReadService retrospectReadService;
 
     @GetMapping
-    public ApiResponse<RetrospectPageResponse> findMonthlyGoalsByCursor(
+    public ApiResponse<RetrospectPageResponse> findRetrospectByPage(
         @LoginUser final DailygeUser dailygeUser,
         @OffsetPageable final CustomPageable page
     ) {

--- a/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectUpdateApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/retrospect/presentation/RetrospectUpdateApi.java
@@ -22,7 +22,7 @@ public class RetrospectUpdateApi {
     private final RetrospectWriteService retrospectWriteService;
 
     @PutMapping(path = "/{retrospectId}")
-    public ApiResponse<Void> update(
+    public ApiResponse<Void> updateRetrospectById(
         @LoginUser final DailygeUser dailygeUser,
         @PathVariable(name = "retrospectId") final Long retrospectId,
         @Valid @RequestBody final RetrospectUpdateRequest request

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/integrationtest/RetrospectReadIntegrationTest.java
@@ -15,7 +15,7 @@ import project.dailyge.app.common.exception.CommonException;
 import project.dailyge.app.core.retrospect.application.RetrospectReadService;
 import project.dailyge.app.core.retrospect.application.RetrospectWriteService;
 import project.dailyge.app.core.retrospect.application.command.RetrospectCreateCommand;
-import project.dailyge.app.core.retrospect.persistence.RetrospectEntityReadDao;
+import project.dailyge.app.core.retrospect.persistence.RetrospectReadDao;
 import project.dailyge.app.paging.CustomPageable;
 import project.dailyge.app.response.AsyncPagingResponse;
 import project.dailyge.entity.retrospect.RetrospectJpaEntity;
@@ -102,13 +102,13 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
         final CustomPageable page = CustomPageable.createPage(1, 10);
         final JdbcTemplate mockJdbcTemplate = mock(JdbcTemplate.class);
         final JPAQueryFactory mockJPAQueryFactory = mock(JPAQueryFactory.class);
-        final RetrospectEntityReadDao retrospectEntityReadDao = new RetrospectEntityReadDao(mockJPAQueryFactory, mockJdbcTemplate);
+        final RetrospectReadDao retrospectReadDao = new RetrospectReadDao(mockJPAQueryFactory, mockJdbcTemplate);
 
         when(mockJdbcTemplate.queryForObject(anyString(), eq(Integer.class), anyLong()))
             .thenThrow(new DataAccessException("Query execution exception") {
             });
 
-        assertThatThrownBy(() -> retrospectEntityReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getUserId(), page))
+        assertThatThrownBy(() -> retrospectReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getUserId(), page))
             .isInstanceOf(CompletionException.class)
             .hasCauseInstanceOf(CommonException.class)
             .hasMessageContaining(DATA_ACCESS_EXCEPTION.message());
@@ -120,13 +120,13 @@ class RetrospectReadIntegrationTest extends DatabaseTestBase {
         final CustomPageable page = CustomPageable.createPage(1, 10);
         final JdbcTemplate mockJdbcTemplate = mock(JdbcTemplate.class);
         final JPAQueryFactory mockJPAQueryFactory = mock(JPAQueryFactory.class);
-        final RetrospectEntityReadDao retrospectEntityReadDao = new RetrospectEntityReadDao(mockJPAQueryFactory, mockJdbcTemplate);
+        final RetrospectReadDao retrospectReadDao = new RetrospectReadDao(mockJPAQueryFactory, mockJdbcTemplate);
 
         when(mockJPAQueryFactory.selectFrom(any()))
             .thenThrow(new DataAccessException("Query execution exception") {
             });
 
-        assertThatThrownBy(() -> retrospectEntityReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getUserId(), page))
+        assertThatThrownBy(() -> retrospectReadDao.findRetrospectAndTotalCountByPage(dailygeUser.getUserId(), page))
             .isInstanceOf(CompletionException.class)
             .hasCauseInstanceOf(CommonException.class)
             .hasMessageContaining(DATA_ACCESS_EXCEPTION.message());


### PR DESCRIPTION
## 📝 작업 내용

이전 회고 조회 API 개발 시 정렬 조건에 **회고 일자**만 넣게 되었는데요. 
이 경우 같은 날짜의 회고가 등록되는 경우 정렬 기준이 모호해서 정렬이 일정하게 되지 않는 경우가 존재하였습니다.

따라서 `id`를 두번째 정렬 조건으로 넣어 동일한 회고일자가 존재하더라도 항상 동일한 정렬 결과가 발생하도록 하였습니다.

- [X] 정렬 조건 추가

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-367)
