### PR TITLE
[DLG-380] Github Workflow 삭제 Shell Script 파일을 추가한다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ index.html
 
 ### .xml ###
 *.xml
+
+### .env ###
+.env

--- a/jib/dailyge-api/jib.gradle
+++ b/jib/dailyge-api/jib.gradle
@@ -5,21 +5,21 @@ if (env != null && (skipJib != null && skipJib == "false")) {
     def ecrUri = env == "prod" ? System.getenv("PROD_ECR_URI") : System.getenv("DEV_ECR_URI")
     def port = env == "prod" ? "8080" : "8081"
     def profile = env == "prod" ? "prod" : "dev"
-    def label = "dailyge-api-${profile}"
+    def label = "dailyge-api-${profile}".toString()
     def imageTag = System.getenv("IMAGE_TAG")
     jib {
         from {
             image = "openjdk:17-jdk-slim"
         }
         to {
-            image = "${ecrUri}:${imageTag}"
+            image = "${ecrUri}:${imageTag}".toString()
             credHelper = "ecr-login"
         }
         container {
             ports = [port]
             labels = [server: label]
             jvmFlags = [
-                    "-Dspring.profiles.active=${profile}",
+                    "-Dspring.profiles.active=${profile}".toString(),
                     "-Dfile.encoding=UTF-8",
                     "-Dlog4j2.formatMsgNoLookups=true",
                     "-XX:+PrintFlagsFinal",

--- a/workflow_cleanup.sh
+++ b/workflow_cleanup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+source .env
+TOKEN="${GITHUB_TOKEN}"
+REPO="dailyge/dailyge-server"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  YESTERDAY=$(date -v -1d +%Y-%m-%dT%H:%M:%SZ)
+else
+  YESTERDAY=$(date -d "1 day ago" +%Y-%m-%dT%H:%M:%SZ)
+fi
+
+for run_id in $(curl -s -H "Authorization: token $TOKEN" \
+  "https://api.github.com/repos/$REPO/actions/runs?per_page=100" | \
+  jq -r --arg yesterday "$YESTERDAY" '.workflow_runs[] | select(.created_at < $yesterday) | .id'); do
+    curl -X DELETE -H "Authorization: token $TOKEN" \
+      "https://api.github.com/repos/$REPO/actions/runs/$run_id"
+done


### PR DESCRIPTION
## 📝 작업 내용

Github Workflow를 자동으로 삭제한다고 고생많으셨는데, Github API를 호출해 자동으로 삭제할 수 있도록 쉘 스크립트를 추가했습니다. 굳이 AWS를 활용해 자동화 안 시켜도 될 것 같아서 스크립트로 대체해도 충분할 것 같아요.

- [x] Workflow 삭제 .sh 추가
- [x] jib toString 정의

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-380)
