### PR TITLE
[DLG-382] Cache 조회 방식을 Lookaside로 수정한다.

### DIFF
--- a/admin-api/src/main/java/project/dailyge/app/core/user/persistence/UserCacheWriteDao.java
+++ b/admin-api/src/main/java/project/dailyge/app/core/user/persistence/UserCacheWriteDao.java
@@ -15,7 +15,7 @@ import project.dailyge.core.cache.user.UserCacheWriteRepository;
 @Repository
 public class UserCacheWriteDao implements UserCacheWriteRepository {
 
-    private static final long CACHE_DURATION = 90;
+    private static final long CACHE_DURATION = 14;
 
     private final RedisTemplate<String, byte[]> redisTemplate;
     private final ObjectMapper objectMapper;

--- a/config/schema/schema.sql
+++ b/config/schema/schema.sql
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS users
     nickname          VARCHAR(20)              NOT NULL COMMENT '닉네임',
     profile_image_url VARCHAR(2000)            NULL COMMENT '사용자 이미지',
     user_role         ENUM ('NORMAL', 'ADMIN') NOT NULL COMMENT '사용자 권한',
+    is_blacklist      BOOLEAN                  NULL COMMNET '블랙리스트 여부',
     created_at        TIMESTAMP                NOT NULL COMMENT '생성일',
     created_by        BIGINT                   NULL COMMENT '생성한 사람',
     last_modified_at  TIMESTAMP                NULL COMMENT '최종 수정일',

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/application/UserWriteService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/application/UserWriteService.java
@@ -5,7 +5,7 @@ import project.dailyge.app.core.user.application.command.UserUpdateCommand;
 import project.dailyge.entity.user.UserJpaEntity;
 
 public interface UserWriteService {
-    Long save(String email);
+    Long save(String email, String nickname);
 
     UserJpaEntity save(UserJpaEntity user);
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/application/usecase/UserWriteUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/application/usecase/UserWriteUseCase.java
@@ -30,8 +30,11 @@ public class UserWriteUseCase implements UserWriteService {
 
     @Override
     @Transactional
-    public Long save(final String email) {
-        return userWriteRepository.save(email);
+    public Long save(
+        final String email,
+        final String nickname
+    ) {
+        return userWriteRepository.save(email, nickname);
     }
 
     @Override

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/exception/UserCodeAndMessage.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/exception/UserCodeAndMessage.java
@@ -4,10 +4,10 @@ import project.dailyge.app.codeandmessage.CodeAndMessage;
 
 public enum UserCodeAndMessage implements CodeAndMessage {
 
+    USER_NOT_MATCH(401, "사용자 정보가 일치 하지 않습니다."),
+    USER_SERVICE_UNAVAILABLE(403, "서비스를 이용할 수 없습니다. 관리자에게 문의해주세요."),
     USER_NOT_FOUND(404, "존재하지 않는 사용자 정보 입니다."),
-    EMPTY_USER_ID(404, "사용자 ID가 존재하지 않습니다."),
-    DUPLICATED_EMAIL(422, "이미 존재하는 이메일 계정입니다"),
-    USER_NOT_MATCH(401, "사용자 정보가 일치 하지 않습니다.");
+    DUPLICATED_EMAIL(422, "이미 존재하는 이메일 계정입니다");
 
     private final int code;
     private final String message;

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/exception/UserTypeException.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/exception/UserTypeException.java
@@ -5,8 +5,8 @@ import project.dailyge.app.common.exception.BusinessException;
 import java.util.HashMap;
 import java.util.Map;
 import static project.dailyge.app.core.user.exception.UserCodeAndMessage.DUPLICATED_EMAIL;
-import static project.dailyge.app.core.user.exception.UserCodeAndMessage.EMPTY_USER_ID;
 import static project.dailyge.app.core.user.exception.UserCodeAndMessage.USER_NOT_FOUND;
+import static project.dailyge.app.core.user.exception.UserCodeAndMessage.USER_SERVICE_UNAVAILABLE;
 
 public sealed class UserTypeException extends BusinessException {
 
@@ -18,7 +18,7 @@ public sealed class UserTypeException extends BusinessException {
 
     static {
         exceptionMap.put(USER_NOT_FOUND, new UserNotFoundException(USER_NOT_FOUND));
-        exceptionMap.put(EMPTY_USER_ID, new UserNotFoundException(EMPTY_USER_ID));
+        exceptionMap.put(USER_SERVICE_UNAVAILABLE, new UserServiceUnAvailableException(USER_SERVICE_UNAVAILABLE));
         exceptionMap.put(DUPLICATED_EMAIL, new DuplicatedEmailException(DUPLICATED_EMAIL));
     }
 
@@ -32,6 +32,12 @@ public sealed class UserTypeException extends BusinessException {
 
     private static final class UserNotFoundException extends UserTypeException {
         public UserNotFoundException(final UserCodeAndMessage codeAndMessage) {
+            super(codeAndMessage);
+        }
+    }
+
+    private static final class UserServiceUnAvailableException extends UserTypeException {
+        public UserServiceUnAvailableException(final UserCodeAndMessage codeAndMessage) {
             super(codeAndMessage);
         }
     }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/external/cache/UserCacheReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/external/cache/UserCacheReadUseCase.java
@@ -1,22 +1,55 @@
 package project.dailyge.app.core.user.external.cache;
 
+import java.util.Optional;
+import org.springframework.context.ApplicationEventPublisher;
 import project.dailyge.app.common.annotation.ExternalLayer;
+import project.dailyge.app.core.user.exception.UserTypeException;
+import project.dailyge.app.core.user.persistence.UserReadDao;
 import project.dailyge.core.cache.user.UserCache;
 import project.dailyge.core.cache.user.UserCacheReadRepository;
 import project.dailyge.core.cache.user.UserCacheReadService;
+import project.dailyge.entity.user.UserEvent;
+import project.dailyge.entity.user.UserJpaEntity;
+import static project.dailyge.app.core.user.exception.UserCodeAndMessage.USER_NOT_FOUND;
+import static project.dailyge.app.core.user.exception.UserCodeAndMessage.USER_SERVICE_UNAVAILABLE;
+import static project.dailyge.document.common.UuidGenerator.createTimeBasedUUID;
+import static project.dailyge.entity.common.EventType.UPDATE;
+import static project.dailyge.entity.user.UserEvent.createEvent;
 
-@ExternalLayer(value = "UserCacheReadService")
+@ExternalLayer(value = "UserCacheReadUseCase")
 class UserCacheReadUseCase implements UserCacheReadService {
 
     private final UserCacheReadRepository userCacheReadRepository;
+    private final UserReadDao userReadDao;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public UserCacheReadUseCase(final UserCacheReadRepository userCacheReadRepository) {
+    public UserCacheReadUseCase(
+        final UserCacheReadRepository userCacheReadRepository,
+        final UserReadDao userReadDao,
+        final ApplicationEventPublisher eventPublisher
+    ) {
         this.userCacheReadRepository = userCacheReadRepository;
+        this.userReadDao = userReadDao;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
     public UserCache findById(final Long userId) {
-        return userCacheReadRepository.findById(userId);
+        final UserCache userCache = userCacheReadRepository.findById(userId);
+        if (userCache != null) {
+            return userCache;
+        }
+        final Optional<UserJpaEntity> findUser = userReadDao.findById(userId);
+        if (findUser.isPresent()) {
+            final UserJpaEntity user = findUser.get();
+            if (user.isBlacklist()) {
+                throw UserTypeException.from(USER_SERVICE_UNAVAILABLE);
+            }
+            final UserEvent event = createEvent(userId, createTimeBasedUUID(), UPDATE);
+            eventPublisher.publishEvent(event);
+            return new UserCache(userId, user.getNickname(), user.getEmail(), user.getProfileImageUrl(), user.getRoleAsString());
+        }
+        throw UserTypeException.from(USER_NOT_FOUND);
     }
 
     @Override

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/external/oauth/GoogleOAuthManager.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/external/oauth/GoogleOAuthManager.java
@@ -57,11 +57,11 @@ public class GoogleOAuthManager {
 
     private GoogleUserInfoResponse returnRandomMockUserInfo() {
         final String firstUuid = UUID.randomUUID().toString().substring(0, 7).replace("-", "");
-        final String secondUuid = UUID.randomUUID().toString().replace("-", "");
+        final String secondUuid = UUID.randomUUID().toString().substring(0, 13).replace("-", "");
         final String email = firstUuid + secondUuid;
         final String emailFormat = email + "@gmail.com";
         final String imageUrl = "https://shorturl.at/dejs2";
-        return new GoogleUserInfoResponse(secondUuid, emailFormat, emailFormat, imageUrl, true);
+        return new GoogleUserInfoResponse(secondUuid, email, emailFormat, imageUrl, true);
     }
 
     private GoogleUserInfoResponse returnLocalMockUserInfo() {

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/facade/UserFacade.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/facade/UserFacade.java
@@ -73,7 +73,7 @@ public class UserFacade {
         final GoogleUserInfoResponse response
     ) {
         if (userId == null) {
-            final Long newUserId = userWriteService.save(response.getEmail());
+            final Long newUserId = userWriteService.save(response.getEmail(), response.getName());
             final TaskEvent taskEvent = TaskEvent.createEvent(newUserId, createTimeBasedUUID(), CREATE);
             final UserEvent userEvent = createEvent(newUserId, createTimeBasedUUID(), CREATE);
             executeEvent(userEvent, taskEvent);

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/persistence/UserWriteDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/persistence/UserWriteDao.java
@@ -28,8 +28,11 @@ public class UserWriteDao implements UserEntityWriteRepository {
     }
 
     @Override
-    public Long save(final String email) {
-        final UserJpaEntity newUser = new UserJpaEntity(null, email, email);
+    public Long save(
+        final String email,
+        final String nickname
+    ) {
+        final UserJpaEntity newUser = new UserJpaEntity(null, nickname, email);
         entityManager.persist(newUser);
         return newUser.getId();
     }
@@ -45,8 +48,8 @@ public class UserWriteDao implements UserEntityWriteRepository {
         final String email,
         final String nickname
     ) {
-        final String sql = "INSERT INTO users (id, nickname, email, created_at, deleted, user_role, profile_image_url) "
-            + "VALUES (:id, :nickname, :email, :created_at, :deleted, :user_role, :profile_image_url)";
+        final String sql = "INSERT INTO users (id, nickname, email, created_at, deleted, user_role, profile_image_url, is_blacklist ) "
+            + "VALUES (:id, :nickname, :email, :created_at, :deleted, :user_role, :profile_image_url, :is_blacklist)";
         final Map<String, Object> parameters = new HashMap<>();
         parameters.put("id", userId);
         parameters.put("nickname", nickname);
@@ -55,6 +58,7 @@ public class UserWriteDao implements UserEntityWriteRepository {
         parameters.put("deleted", 0);
         parameters.put("user_role", "NORMAL");
         parameters.put("profile_image_url", "");
+        parameters.put("is_blacklist", false);
         jdbcTemplate.update(sql, new MapSqlParameterSource(parameters));
         return new UserJpaEntity(userId, nickname, email, Role.NORMAL);
     }

--- a/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
+++ b/dailyge-api/src/main/resources/db/rdb/changelog/release-1.0.0/schema.sql
@@ -68,6 +68,7 @@ CREATE TABLE IF NOT EXISTS users
     nickname          VARCHAR(20)              NOT NULL COMMENT '닉네임',
     profile_image_url VARCHAR(2000)            NULL COMMENT '사용자 이미지',
     user_role         ENUM ('NORMAL', 'ADMIN') NOT NULL COMMENT '사용자 권한',
+    is_blacklist      BOOLEAN                  NULL COMMNET '블랙리스트 여부',
     created_at        TIMESTAMP                NOT NULL COMMENT '생성일',
     created_by        BIGINT                   NULL COMMENT '생성한 사람',
     last_modified_at  TIMESTAMP                NULL COMMENT '최종 수정일',

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/unittest/GoogleOAuthManagerUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/unittest/GoogleOAuthManagerUnitTest.java
@@ -51,7 +51,6 @@ class GoogleOAuthManagerUnitTest {
             () -> assertNotNull(mockUserInfo.getEmail()),
             () -> assertNotNull(mockUserInfo.getPicture()),
             () -> assertTrue(mockUserInfo.isVerifiedEmail()),
-            () -> assertEquals(mockUserInfo.getName(), mockUserInfo.getEmail()),
             () -> assertEquals("https://shorturl.at/dejs2", mockUserInfo.getPicture())
         );
     }

--- a/storage/rdb/src/main/java/project/dailyge/entity/user/UserEntityWriteRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/user/UserEntityWriteRepository.java
@@ -1,7 +1,7 @@
 package project.dailyge.entity.user;
 
 public interface UserEntityWriteRepository {
-    Long save(String email);
+    Long save(String email, String nickname);
 
     UserJpaEntity save(UserJpaEntity user);
 

--- a/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
@@ -42,6 +42,9 @@ public class UserJpaEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(name = "is_blacklist")
+    private boolean isBlacklist;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
@@ -51,13 +54,23 @@ public class UserJpaEntity extends BaseEntity {
     public UserJpaEntity(
         final Long id,
         final String nickname,
-        final String email
+        final String email,
+        final boolean isBlacklist
     ) {
         validate(nickname, email, "");
         this.id = id;
         this.nickname = nickname;
         this.email = email;
         this.role = Role.NORMAL;
+        this.isBlacklist = isBlacklist;
+    }
+
+    public UserJpaEntity(
+        final Long id,
+        final String nickname,
+        final String email
+    ) {
+        this(id, nickname, email, false);
     }
 
     public UserJpaEntity(
@@ -71,6 +84,7 @@ public class UserJpaEntity extends BaseEntity {
         this.nickname = nickname;
         this.email = email;
         this.role = Role.NORMAL;
+        this.isBlacklist = false;
         init(createdAt, id, null, null, false);
     }
 
@@ -85,6 +99,7 @@ public class UserJpaEntity extends BaseEntity {
         this.nickname = nickname;
         this.email = email;
         this.role = role;
+        this.isBlacklist = false;
     }
 
     public UserJpaEntity(
@@ -99,6 +114,7 @@ public class UserJpaEntity extends BaseEntity {
         this.email = email;
         this.profileImageUrl = profileImageUrl;
         this.role = Role.NORMAL;
+        this.isBlacklist = false;
     }
 
     public Long getId() {
@@ -195,6 +211,15 @@ public class UserJpaEntity extends BaseEntity {
     public String getUserAlreadyDeletedMessage() {
         return USER_ALREADY_DELETED_MESSAGE;
     }
+
+    public boolean isBlacklist() {
+        return isBlacklist;
+    }
+
+    public boolean getBlacklist() {
+        return isBlacklist;
+    }
+
 
     @Override
     public boolean equals(final Object obj) {


### PR DESCRIPTION
## 📝 작업 내용

캐시 조회 방식을 Lookaside로 변경하였습니다. 사용자 캐시 조회 시 캐시에 없을 때, RDB에서 조회해서 캐시에 업데이트 하는 방식입니다.

- [X] 캐시 조회 방식 Lookaside로 변경
- [X] dev 환경 nickname 20자 이내로 설정
- [X] 캐시 조회 방식 변경에 따른 테스트 코드 수정

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-382)
