### PR TITLE
[DLG-386] 로그아웃 시 사용자 캐시를 삭제한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/common/utils/CookieUtils.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/utils/CookieUtils.java
@@ -23,7 +23,7 @@ public final class CookieUtils {
             final ResponseCookie cookie = ResponseCookie.from(name, value)
                 .domain(ROOT_DOMAIN)
                 .path(path)
-                .httpOnly(true)
+                .httpOnly(httpOnly)
                 .secure(true)
                 .maxAge(maxAge)
                 .build();

--- a/dailyge-api/src/main/java/project/dailyge/app/common/utils/CookieUtils.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/common/utils/CookieUtils.java
@@ -23,8 +23,8 @@ public final class CookieUtils {
             final ResponseCookie cookie = ResponseCookie.from(name, value)
                 .domain(ROOT_DOMAIN)
                 .path(path)
-                .httpOnly(false)
-                .secure(false)
+                .httpOnly(true)
+                .secure(true)
                 .maxAge(maxAge)
                 .build();
             return cookie.toString();

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/facade/UserFacade.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/facade/UserFacade.java
@@ -98,12 +98,12 @@ public class UserFacade {
     }
 
     public void logout(final Long userId) {
+        userCacheWriteService.delete(userId);
         tokenManager.deleteRefreshToken(userId);
     }
 
     public void delete(final Long userId) {
         userWriteService.delete(userId);
-        userCacheWriteService.delete(userId);
         logout(userId);
     }
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/CookieUtilsUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/CookieUtilsUnitTest.java
@@ -76,7 +76,7 @@ class CookieUtilsUnitTest {
             () -> assertTrue(cookieString.contains("Domain=.dailyge.com")),
             () -> assertTrue(cookieString.contains("Path=" + COOKIE_PATH)),
             () -> assertTrue(cookieString.contains("Secure")),
-            () -> assertFalse(cookieString.contains("HttpOnly"))
+            () -> assertTrue(cookieString.contains("HttpOnly"))
         );
     }
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/CookieUtilsUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/CookieUtilsUnitTest.java
@@ -75,7 +75,7 @@ class CookieUtilsUnitTest {
             () -> assertTrue(cookieString.contains("Max-Age=86400")),
             () -> assertTrue(cookieString.contains("Domain=.dailyge.com")),
             () -> assertTrue(cookieString.contains("Path=" + COOKIE_PATH)),
-            () -> assertFalse(cookieString.contains("Secure")),
+            () -> assertTrue(cookieString.contains("Secure")),
             () -> assertFalse(cookieString.contains("HttpOnly"))
         );
     }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/DailygeTokenUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/DailygeTokenUnitTest.java
@@ -28,8 +28,8 @@ class DailygeTokenUnitTest {
             () -> assertTrue(accessTokenCookie.contains("Access-Token=accessTokenValue")),
             () -> assertTrue(accessTokenCookie.contains("Max-Age=1800")),
             () -> assertTrue(accessTokenCookie.contains("Path=/")),
-            () -> assertFalse(accessTokenCookie.contains("Secure")),
-            () -> assertFalse(accessTokenCookie.contains("HttpOnly")),
+            () -> assertTrue(accessTokenCookie.contains("Secure")),
+            () -> assertTrue(accessTokenCookie.contains("HttpOnly")),
             () -> assertTrue(accessTokenCookie.contains("Domain=.dailyge.com"))
         );
     }
@@ -43,8 +43,8 @@ class DailygeTokenUnitTest {
             () -> assertTrue(refreshTokenCookie.contains("Refresh-Token=refreshTokenValue")),
             () -> assertTrue(refreshTokenCookie.contains("Max-Age=2592000")),
             () -> assertTrue(refreshTokenCookie.contains("Path=/")),
-            () -> assertFalse(refreshTokenCookie.contains("Secure")),
-            () -> assertFalse(refreshTokenCookie.contains("HttpOnly")),
+            () -> assertTrue(refreshTokenCookie.contains("Secure")),
+            () -> assertTrue(refreshTokenCookie.contains("HttpOnly")),
             () -> assertTrue(refreshTokenCookie.contains("Domain=.dailyge.com"))
         );
     }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/integrationtest/LoginIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/integrationtest/LoginIntegrationTest.java
@@ -21,11 +21,14 @@ import project.dailyge.entity.user.UserEvent;
 import project.dailyge.entity.user.UserJpaEntity;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static project.dailyge.app.core.user.exception.UserCodeAndMessage.USER_SERVICE_UNAVAILABLE;
 import static project.dailyge.app.test.user.fixture.UserFixture.EMAIL;
 import static project.dailyge.app.test.user.fixture.UserFixture.NICKNAME;
+import static project.dailyge.app.test.user.fixture.UserFixture.user;
 
 @DisplayName("[IntegrationTest] Login 통합 테스트")
 class LoginIntegrationTest extends DatabaseTestBase {
@@ -100,5 +103,14 @@ class LoginIntegrationTest extends DatabaseTestBase {
         when(mockGoogleOAuthManager.getUserInfo(CODE)).thenReturn(response);
 
         assertDoesNotThrow(() -> userFacade.login(CODE));
+    }
+
+    @Test
+    @DisplayName("사용자가 로그아웃하면, 캐시가 삭제된다.")
+    void whenUserLogoutThenUserCacheShouldBeNull() {
+        userFacade.logout(1L);
+
+        assertNull(tokenManager.getRefreshToken(user.getId()));
+        assertFalse(userCacheReadService.existsById(dailygeUser.getUserId()));
     }
 }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/integrationtest/UserDeleteIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/integrationtest/UserDeleteIntegrationTest.java
@@ -11,6 +11,7 @@ import project.dailyge.app.core.user.application.UserWriteService;
 import static project.dailyge.app.core.user.exception.UserCodeAndMessage.USER_NOT_FOUND;
 import project.dailyge.app.core.user.exception.UserTypeException;
 import static project.dailyge.app.test.user.fixture.UserFixture.createUser;
+import project.dailyge.app.core.user.facade.UserFacade;
 import project.dailyge.entity.user.UserJpaEntity;
 
 @DisplayName("[IntegrationTest] 사용자 삭제 통합 테스트")
@@ -22,10 +23,13 @@ class UserDeleteIntegrationTest extends DatabaseTestBase {
     @Autowired
     private UserWriteService userWriteService;
 
+    @Autowired
+    private UserFacade userFacade;
+
     @Test
     @DisplayName("존재하는 사용자를 삭제하면, deleted true로 논리삭제 된다.")
     void whenDeleteAnExistingUserThenUserShouldDeletedBeTrue() {
-        userWriteService.delete(dailygeUser.getId());
+        userFacade.delete(dailygeUser.getId());
         final UserJpaEntity findUser = userReadService.findById(dailygeUser.getId());
 
         assertTrue(findUser.getDeleted());
@@ -46,7 +50,7 @@ class UserDeleteIntegrationTest extends DatabaseTestBase {
     @Test
     @DisplayName("존재하지 않는 사용자를 삭제하면, UserNotFoundException이 발생한다.")
     void whenDeleteNonExistentUserThenUserNotFoundExceptionShouldBeHappen() {
-        assertThatThrownBy(() -> userWriteService.delete(999L))
+        assertThatThrownBy(() -> userFacade.delete(999L))
             .isExactlyInstanceOf(UserTypeException.from(USER_NOT_FOUND).getClass())
             .isInstanceOf(UserTypeException.class)
             .hasMessage(USER_NOT_FOUND.message());


### PR DESCRIPTION
## 📝 작업 내용
기존에는 로그아웃 시 캐시 정보를 그대로 두었습니다. 이후 팀원분의 의견으로 사용자가 언제 다시 로그인할지 알 수 없으므로 불필요한 데이터를 메모리에 올려놓을 필요가 없을 것 같아, 로그아웃할 때 캐시도 함께 삭제하기로 의사 결정을 했습니다.

- [X] 로그아웃 시 사용자 캐시 삭제
- [X] JWT 쿠키 설정 복구

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-386)
