### PR TITLE
[DLG-388] 쪽지 목록 조회 API를 개발한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/application/NoteReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/application/NoteReadService.java
@@ -1,6 +1,5 @@
 package project.dailyge.app.core.note.application;
 
-import project.dailyge.api.CursorPagingResponse;
 import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.note.NoteJpaEntity;
@@ -12,9 +11,9 @@ public interface NoteReadService {
 
     NoteJpaEntity findSentNotesById(DailygeUser dailygeUser, Long noteId);
 
-    CursorPagingResponse<NoteJpaEntity> findSentNotesById(DailygeUser dailygeUser, Cursor cursor);
+    List<NoteJpaEntity> findSentNotesById(DailygeUser dailygeUser, Cursor cursor);
 
-    CursorPagingResponse<NoteJpaEntity> findReceivedNotesById(DailygeUser dailygeUser, Cursor cursor);
+    List<NoteJpaEntity> findReceivedNotesById(DailygeUser dailygeUser, Cursor cursor);
 
     List<NoteJpaEntity> findAll();
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/application/NoteReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/application/NoteReadService.java
@@ -1,6 +1,8 @@
 package project.dailyge.app.core.note.application;
 
+import project.dailyge.api.CursorPagingResponse;
 import project.dailyge.app.core.common.auth.DailygeUser;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.note.NoteJpaEntity;
 
 import java.util.List;
@@ -8,7 +10,11 @@ import java.util.List;
 public interface NoteReadService {
     NoteJpaEntity findReceivedNoteById(DailygeUser dailygeUser, Long noteId);
 
-    NoteJpaEntity findSentNoteById(DailygeUser dailygeUser, Long noteId);
+    NoteJpaEntity findSentNotesById(DailygeUser dailygeUser, Long noteId);
+
+    CursorPagingResponse<NoteJpaEntity> findSentNotesById(DailygeUser dailygeUser, Cursor cursor);
+
+    CursorPagingResponse<NoteJpaEntity> findReceivedNotesById(DailygeUser dailygeUser, Cursor cursor);
 
     List<NoteJpaEntity> findAll();
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/application/usecase/NoteReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/application/usecase/NoteReadUseCase.java
@@ -2,7 +2,6 @@ package project.dailyge.app.core.note.application.usecase;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
-import project.dailyge.api.CursorPagingResponse;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.UN_AUTHORIZED;
 import project.dailyge.app.common.annotation.ApplicationLayer;
 import project.dailyge.app.common.exception.CommonException;
@@ -65,29 +64,26 @@ class NoteReadUseCase implements NoteReadService {
     }
 
     @Override
-    public CursorPagingResponse<NoteJpaEntity> findSentNotesById(
+    @Transactional(readOnly = true)
+    public List<NoteJpaEntity> findSentNotesById(
         final DailygeUser dailygeUser,
         final Cursor cursor
     ) {
         if (cursor.isNull()) {
-            final List<NoteJpaEntity> findNotes = noteReadRepository.findSentNotesById(dailygeUser.getUserId(), cursor.getLimit());
-            return new CursorPagingResponse<>(findNotes, cursor.getLimit());
+            return noteReadRepository.findSentNotesById(dailygeUser.getUserId(), cursor.getLimit());
         }
-        final List<NoteJpaEntity> findNotes = noteReadRepository.findSentNotesById(dailygeUser.getUserId(), cursor.getIndex(), cursor.getLimit());
-        return new CursorPagingResponse<>(findNotes, cursor.getLimit());
+        return noteReadRepository.findSentNotesById(dailygeUser.getUserId(), cursor.getIndex(), cursor.getLimit());
     }
 
     @Override
-    public CursorPagingResponse<NoteJpaEntity> findReceivedNotesById(
+    public List<NoteJpaEntity> findReceivedNotesById(
         final DailygeUser dailygeUser,
         final Cursor cursor
     ) {
         if (cursor.isNull()) {
-            final List<NoteJpaEntity> findNotes = noteReadRepository.findReceivedNotesById(dailygeUser.getUserId(), cursor.getLimit());
-            return new CursorPagingResponse<>(findNotes, cursor.getLimit());
+            return noteReadRepository.findReceivedNotesById(dailygeUser.getUserId(), cursor.getLimit());
         }
-        final List<NoteJpaEntity> findNotes = noteReadRepository.findReceivedNotesById(dailygeUser.getUserId(), cursor.getIndex(), cursor.getLimit());
-        return new CursorPagingResponse<>(findNotes, cursor.getLimit());
+        return noteReadRepository.findReceivedNotesById(dailygeUser.getUserId(), cursor.getIndex(), cursor.getLimit());
     }
 
     @Override

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/application/usecase/NoteReadUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/application/usecase/NoteReadUseCase.java
@@ -2,6 +2,7 @@ package project.dailyge.app.core.note.application.usecase;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
+import project.dailyge.api.CursorPagingResponse;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.UN_AUTHORIZED;
 import project.dailyge.app.common.annotation.ApplicationLayer;
 import project.dailyge.app.common.exception.CommonException;
@@ -9,6 +10,7 @@ import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.note.application.NoteReadService;
 import static project.dailyge.app.core.note.exception.NoteCodeAndMessage.NOTE_NOT_FOUND;
 import project.dailyge.app.core.note.exception.NoteTypeException;
+import project.dailyge.app.paging.Cursor;
 import static project.dailyge.document.common.UuidGenerator.createTimeBasedUUID;
 import static project.dailyge.entity.common.EventType.UPDATE;
 import project.dailyge.entity.note.NoteEntityReadRepository;
@@ -50,7 +52,7 @@ class NoteReadUseCase implements NoteReadService {
     }
 
     @Override
-    public NoteJpaEntity findSentNoteById(
+    public NoteJpaEntity findSentNotesById(
         final DailygeUser dailygeUser,
         final Long noteId
     ) {
@@ -60,6 +62,32 @@ class NoteReadUseCase implements NoteReadService {
             throw CommonException.from(UN_AUTHORIZED);
         }
         return findNote;
+    }
+
+    @Override
+    public CursorPagingResponse<NoteJpaEntity> findSentNotesById(
+        final DailygeUser dailygeUser,
+        final Cursor cursor
+    ) {
+        if (cursor.isNull()) {
+            final List<NoteJpaEntity> findNotes = noteReadRepository.findSentNotesById(dailygeUser.getUserId(), cursor.getLimit());
+            return new CursorPagingResponse<>(findNotes, cursor.getLimit());
+        }
+        final List<NoteJpaEntity> findNotes = noteReadRepository.findSentNotesById(dailygeUser.getUserId(), cursor.getIndex(), cursor.getLimit());
+        return new CursorPagingResponse<>(findNotes, cursor.getLimit());
+    }
+
+    @Override
+    public CursorPagingResponse<NoteJpaEntity> findReceivedNotesById(
+        final DailygeUser dailygeUser,
+        final Cursor cursor
+    ) {
+        if (cursor.isNull()) {
+            final List<NoteJpaEntity> findNotes = noteReadRepository.findReceivedNotesById(dailygeUser.getUserId(), cursor.getLimit());
+            return new CursorPagingResponse<>(findNotes, cursor.getLimit());
+        }
+        final List<NoteJpaEntity> findNotes = noteReadRepository.findReceivedNotesById(dailygeUser.getUserId(), cursor.getIndex(), cursor.getLimit());
+        return new CursorPagingResponse<>(findNotes, cursor.getLimit());
     }
 
     @Override

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/persistence/NoteReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/persistence/NoteReadDao.java
@@ -66,10 +66,10 @@ class NoteReadDao implements NoteEntityReadRepository {
         return queryFactory.selectFrom(noteJpaEntity)
             .where(
                 noteJpaEntity.senderId.eq(userId)
-                    .and(noteJpaEntity.senderId.lt(userId))
                     .and(noteJpaEntity._senderDeleted.eq(false))
             )
             .limit(size + 1)
+            .orderBy(noteJpaEntity.id.desc())
             .fetch();
     }
 
@@ -82,10 +82,11 @@ class NoteReadDao implements NoteEntityReadRepository {
         return queryFactory.selectFrom(noteJpaEntity)
             .where(
                 noteJpaEntity.senderId.eq(userId)
-                    .and(noteJpaEntity.senderId.lt(index))
+                    .and(noteJpaEntity.id.lt(index))
                     .and(noteJpaEntity._senderDeleted.eq(false))
             )
             .limit(size + 1)
+            .orderBy(noteJpaEntity.id.desc())
             .fetch();
     }
 
@@ -96,11 +97,11 @@ class NoteReadDao implements NoteEntityReadRepository {
     ) {
         return queryFactory.selectFrom(noteJpaEntity)
             .where(
-                noteJpaEntity.senderId.eq(userId)
-                    .and(noteJpaEntity.receiverId.lt(userId))
+                noteJpaEntity.receiverId.eq(userId)
                     .and(noteJpaEntity._receiverDeleted.eq(false))
             )
             .limit(size + 1)
+            .orderBy(noteJpaEntity.id.desc())
             .fetch();
     }
 
@@ -112,11 +113,12 @@ class NoteReadDao implements NoteEntityReadRepository {
     ) {
         return queryFactory.selectFrom(noteJpaEntity)
             .where(
-                noteJpaEntity.senderId.eq(userId)
-                    .and(noteJpaEntity.receiverId.lt(index))
+                noteJpaEntity.receiverId.eq(userId)
+                    .and(noteJpaEntity.id.lt(index))
                     .and(noteJpaEntity._receiverDeleted.eq(false))
             )
             .limit(size + 1)
+            .orderBy(noteJpaEntity.id.desc())
             .fetch();
     }
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/persistence/NoteReadDao.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/persistence/NoteReadDao.java
@@ -58,14 +58,68 @@ class NoteReadDao implements NoteEntityReadRepository {
                 .fetchOne());
     }
 
-    /**
-     * Method created for testing purposes; should not be called in a production environment.
-     * <p>
-     * <b>Warning:</b> This method is intended for testing use only and should not be used in production.
-     * </p>
-     *
-     * @return a list of all {@link NoteJpaEntity} entities
-     */
+    @Override
+    public List<NoteJpaEntity> findSentNotesById(
+        final Long userId,
+        final Integer size
+    ) {
+        return queryFactory.selectFrom(noteJpaEntity)
+            .where(
+                noteJpaEntity.senderId.eq(userId)
+                    .and(noteJpaEntity.senderId.lt(userId))
+                    .and(noteJpaEntity._senderDeleted.eq(false))
+            )
+            .limit(size + 1)
+            .fetch();
+    }
+
+    @Override
+    public List<NoteJpaEntity> findSentNotesById(
+        final Long userId,
+        final Long index,
+        final Integer size
+    ) {
+        return queryFactory.selectFrom(noteJpaEntity)
+            .where(
+                noteJpaEntity.senderId.eq(userId)
+                    .and(noteJpaEntity.senderId.lt(index))
+                    .and(noteJpaEntity._senderDeleted.eq(false))
+            )
+            .limit(size + 1)
+            .fetch();
+    }
+
+    @Override
+    public List<NoteJpaEntity> findReceivedNotesById(
+        final Long userId,
+        final Integer size
+    ) {
+        return queryFactory.selectFrom(noteJpaEntity)
+            .where(
+                noteJpaEntity.senderId.eq(userId)
+                    .and(noteJpaEntity.receiverId.lt(userId))
+                    .and(noteJpaEntity._receiverDeleted.eq(false))
+            )
+            .limit(size + 1)
+            .fetch();
+    }
+
+    @Override
+    public List<NoteJpaEntity> findReceivedNotesById(
+        final Long userId,
+        final Long index,
+        final Integer size
+    ) {
+        return queryFactory.selectFrom(noteJpaEntity)
+            .where(
+                noteJpaEntity.senderId.eq(userId)
+                    .and(noteJpaEntity.receiverId.lt(index))
+                    .and(noteJpaEntity._receiverDeleted.eq(false))
+            )
+            .limit(size + 1)
+            .fetch();
+    }
+
     @Override
     public List<NoteJpaEntity> findAll() {
         return queryFactory.selectFrom(noteJpaEntity)

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/presentation/NoteReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/presentation/NoteReadApi.java
@@ -16,6 +16,8 @@ import project.dailyge.app.core.note.presentation.response.SentNoteResponse;
 import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.note.NoteJpaEntity;
 
+import java.util.List;
+
 @RequestMapping(path = "/api/notes")
 @PresentationLayer(value = "NoteReadApi")
 public class NoteReadApi {
@@ -37,11 +39,14 @@ public class NoteReadApi {
     }
 
     @GetMapping(path = "/sent")
-    public ApiResponse<CursorPagingResponse<NoteJpaEntity>> findSentNotesById(
+    public ApiResponse<CursorPagingResponse<SentNoteResponse>> findSentNotesById(
         @LoginUser final DailygeUser dailygeUser,
         @CursorPageable final Cursor cursor
     ) {
-        final CursorPagingResponse<NoteJpaEntity> payload = noteReadService.findSentNotesById(dailygeUser, cursor);
+        final List<SentNoteResponse> findNotes = noteReadService.findSentNotesById(dailygeUser, cursor).stream()
+            .map(SentNoteResponse::new)
+            .toList();
+        final CursorPagingResponse<SentNoteResponse> payload = new CursorPagingResponse<>(findNotes, cursor.getLimit());
         return ApiResponse.from(OK, payload);
     }
 
@@ -56,11 +61,14 @@ public class NoteReadApi {
     }
 
     @GetMapping(path = "/received")
-    public ApiResponse<CursorPagingResponse<NoteJpaEntity>> findReceivedNotesById(
+    public ApiResponse<CursorPagingResponse<ReceivedNoteResponse>> findReceivedNotesById(
         @LoginUser final DailygeUser dailygeUser,
         @CursorPageable final Cursor cursor
     ) {
-        final CursorPagingResponse<NoteJpaEntity> payload = noteReadService.findReceivedNotesById(dailygeUser, cursor);
+        final List<ReceivedNoteResponse> findNotes = noteReadService.findReceivedNotesById(dailygeUser, cursor).stream()
+            .map(ReceivedNoteResponse::new)
+            .toList();
+        final CursorPagingResponse<ReceivedNoteResponse> payload = new CursorPagingResponse<>(findNotes, cursor.getLimit());
         return ApiResponse.from(OK, payload);
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/presentation/NoteReadApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/presentation/NoteReadApi.java
@@ -3,7 +3,9 @@ package project.dailyge.app.core.note.presentation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import project.dailyge.api.CursorPagingResponse;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.OK;
+import project.dailyge.app.common.annotation.CursorPageable;
 import project.dailyge.app.common.annotation.LoginUser;
 import project.dailyge.app.common.annotation.PresentationLayer;
 import project.dailyge.app.common.response.ApiResponse;
@@ -11,6 +13,7 @@ import project.dailyge.app.core.common.auth.DailygeUser;
 import project.dailyge.app.core.note.application.NoteReadService;
 import project.dailyge.app.core.note.presentation.response.ReceivedNoteResponse;
 import project.dailyge.app.core.note.presentation.response.SentNoteResponse;
+import project.dailyge.app.paging.Cursor;
 import project.dailyge.entity.note.NoteJpaEntity;
 
 @RequestMapping(path = "/api/notes")
@@ -28,8 +31,17 @@ public class NoteReadApi {
         @LoginUser final DailygeUser dailygeUser,
         @PathVariable(name = "noteId") final Long noteId
     ) {
-        final NoteJpaEntity findNote = noteReadService.findSentNoteById(dailygeUser, noteId);
+        final NoteJpaEntity findNote = noteReadService.findSentNotesById(dailygeUser, noteId);
         final SentNoteResponse payload = new SentNoteResponse(findNote);
+        return ApiResponse.from(OK, payload);
+    }
+
+    @GetMapping(path = "/sent")
+    public ApiResponse<CursorPagingResponse<NoteJpaEntity>> findSentNotesById(
+        @LoginUser final DailygeUser dailygeUser,
+        @CursorPageable final Cursor cursor
+    ) {
+        final CursorPagingResponse<NoteJpaEntity> payload = noteReadService.findSentNotesById(dailygeUser, cursor);
         return ApiResponse.from(OK, payload);
     }
 
@@ -40,6 +52,15 @@ public class NoteReadApi {
     ) {
         final NoteJpaEntity findNote = noteReadService.findReceivedNoteById(dailygeUser, noteId);
         final ReceivedNoteResponse payload = new ReceivedNoteResponse(findNote);
+        return ApiResponse.from(OK, payload);
+    }
+
+    @GetMapping(path = "/received")
+    public ApiResponse<CursorPagingResponse<NoteJpaEntity>> findReceivedNotesById(
+        @LoginUser final DailygeUser dailygeUser,
+        @CursorPageable final Cursor cursor
+    ) {
+        final CursorPagingResponse<NoteJpaEntity> payload = noteReadService.findReceivedNotesById(dailygeUser, cursor);
         return ApiResponse.from(OK, payload);
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/presentation/response/ReceivedNoteResponse.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/presentation/response/ReceivedNoteResponse.java
@@ -7,6 +7,7 @@ public class ReceivedNoteResponse {
     private Long noteId;
     private String title;
     private String content;
+    private String sentAt;
 
     private ReceivedNoteResponse() {
     }
@@ -15,6 +16,7 @@ public class ReceivedNoteResponse {
         this.noteId = note.getId();
         this.title = note.getTitle();
         this.content = note.getContent();
+        this.sentAt = note.getSentAtAsString();
     }
 
     public Long getNoteId() {
@@ -27,6 +29,10 @@ public class ReceivedNoteResponse {
 
     public String getContent() {
         return content;
+    }
+
+    public String getSentAt() {
+        return sentAt;
     }
 
     @Override

--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/presentation/response/SentNoteResponse.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/presentation/response/SentNoteResponse.java
@@ -7,6 +7,7 @@ public class SentNoteResponse {
     private Long noteId;
     private String title;
     private String content;
+    private String sentAt;
     private boolean read;
 
     private SentNoteResponse() {
@@ -16,6 +17,7 @@ public class SentNoteResponse {
         this.noteId = note.getId();
         this.title = note.getTitle();
         this.content = note.getContent();
+        this.sentAt = note.getSentAtAsString();
         this.read = note.isRead();
     }
 
@@ -29,6 +31,10 @@ public class SentNoteResponse {
 
     public String getContent() {
         return content;
+    }
+
+    public String getSentAt() {
+        return sentAt;
     }
 
     public boolean isRead() {

--- a/dailyge-api/src/test/java/project/dailyge/app/test/note/documentationtest/NoteReadDocumentationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/note/documentationtest/NoteReadDocumentationTest.java
@@ -12,6 +12,8 @@ import project.dailyge.app.common.DatabaseTestBase;
 import project.dailyge.app.core.note.facade.NoteFacade;
 import project.dailyge.app.core.note.presentation.request.NoteCreateRequest;
 import static project.dailyge.app.test.note.documentationtest.snippet.NoteReadSnippet.createReceivedNoteDetailReadFilter;
+import static project.dailyge.app.test.note.documentationtest.snippet.NoteReadSnippet.createReceivedNotesReadFilter;
+import static project.dailyge.app.test.note.documentationtest.snippet.NoteReadSnippet.createSentNotesReadFilter;
 import project.dailyge.app.test.note.documentationtest.snippet.NoteSnippet;
 import static project.dailyge.app.test.task.documentationtest.snippet.TaskSnippet.createIdentifier;
 import static project.dailyge.app.test.task.documentationtest.snippet.TaskSnippet.identifier;
@@ -154,5 +156,87 @@ class NoteReadDocumentationTest extends DatabaseTestBase {
             .get("/api/notes/{noteId}/received", invalidNoteId)
             .then()
             .statusCode(404);
+    }
+
+    @Test
+    @DisplayName("[RestDocs] 발신자가 보낸 쪽지 목록을 조회하면 200 OK 응답을 받는다.")
+    void whenSenderReadSentNotesThenStatusCodeShouldBe_200_OK_RestDocs() {
+        final LocalDateTime date = LocalDateTime.of(2021, 10, 1, 0, 0, 0);
+        final NoteCreateRequest request = new NoteCreateRequest("주간 일정 회의", "주간 일정 회의 신청합니다.", "kmularise", date);
+        noteFacade.save(dailygeUser, request.toCommand(dailygeUser), 30);
+
+        given(this.specification)
+            .filter(document(identifier,
+                ACCESS_TOKEN_COOKIE_SNIPPET,
+                NoteSnippet.Companion.getNOTE_CURSOR_REQUEST_PARAMETER_SNIPPET(),
+                NoteSnippet.Companion.getSENT_NOTE_RESPONSE_SNIPPET()
+            ))
+            .when()
+            .cookie(getAccessTokenCookie())
+            .param("size", 10)
+            .param("index", 2)
+            .get("/api/notes/sent")
+            .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("[Swagger] 발신자가 보낸 쪽지 목록을 조회하면 200 OK 응답을 받는다.")
+    void whenSenderReadSentNotesThenStatusCodeShouldBe_200_OK_Swagger() {
+        final LocalDateTime date = LocalDateTime.of(2021, 10, 1, 0, 0, 0);
+        final NoteCreateRequest request = new NoteCreateRequest("주간 일정 회의", "주간 일정 회의 신청합니다.", "kmularise", date);
+        noteFacade.save(dailygeUser, request.toCommand(dailygeUser), 30);
+
+        final RestDocumentationFilter filter = createSentNotesReadFilter(createIdentifier("SentNotesRead", 200));
+        given(this.specification)
+            .filter(filter)
+            .when()
+            .cookie(getAccessTokenCookie())
+            .param("size", 10)
+            .param("index", 2)
+            .get("/api/notes/sent")
+            .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("[RestDocs] 수신자가 받은 쪽지 목록을 조회하면 200 OK 응답을 받는다.")
+    void whenReceiverReadReceivedNotesThenStatusCodeShouldBe_200_OK_RestDocs() {
+        final LocalDateTime date = LocalDateTime.of(2021, 10, 1, 0, 0, 0);
+        final NoteCreateRequest request = new NoteCreateRequest("주간 일정 회의", "주간 일정 회의 신청합니다.", "kmularise", date);
+        noteFacade.save(dailygeUser, request.toCommand(dailygeUser), 30);
+
+        given(this.specification)
+            .filter(document(identifier,
+                ACCESS_TOKEN_COOKIE_SNIPPET,
+                NoteSnippet.Companion.getNOTE_CURSOR_REQUEST_PARAMETER_SNIPPET(),
+                NoteSnippet.Companion.getRECEIVED_NOTE_RESPONSE_SNIPPET()
+            ))
+            .when()
+            .cookie(getNoteReceiverAccessTokenCookie())
+            .param("size", 10)
+            .param("index", 2)
+            .get("/api/notes/received")
+            .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @DisplayName("[Swagger] 수신자가 받은 쪽지 목록을 조회하면 200 OK 응답을 받는다.")
+    void whenReceiverReadReceivedNotesThenStatusCodeShouldBe_200_OK_Swagger() {
+        final LocalDateTime date = LocalDateTime.of(2021, 10, 1, 0, 0, 0);
+        final NoteCreateRequest request = new NoteCreateRequest("주간 일정 회의", "주간 일정 회의 신청합니다.", "kmularise", date);
+        noteFacade.save(dailygeUser, request.toCommand(dailygeUser), 30);
+        final RestDocumentationFilter filter = createReceivedNotesReadFilter(createIdentifier("ReceivedNotesRead", 200));
+
+        given(this.specification)
+            .filter(filter)
+            .when()
+            .cookie(getNoteReceiverAccessTokenCookie())
+            .param("size", 10)
+            .param("index", 2)
+            .get("/api/notes/received")
+            .then()
+            .statusCode(200);
     }
 }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/note/documentationtest/snippet/NoteReadSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/note/documentationtest/snippet/NoteReadSnippet.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import org.springframework.restdocs.restassured.RestDocumentationFilter;
 import static project.dailyge.app.common.CommonSnippet.COOKIE_HEADER_DESCRIPTORS;
 import static project.dailyge.app.common.CommonSnippet.ERROR_RESPONSE;
@@ -44,6 +45,56 @@ public final class NoteReadSnippet implements NoteSnippet {
                     requestCookies(TOKEN_COOKIE_DESCRIPTORS),
                     pathParameters(Companion.getNOTE_ID_PATH_PARAMETER_DESCRIPTORS()),
                     responseFields(Companion.getSENT_NOTE_DETAIL_READ_RESPONSE_FIELDS().stream().toList()),
+                    responseFields(Arrays.stream(ERROR_RESPONSE).toList())
+                );
+            }
+        );
+    }
+
+    public static RestDocumentationFilter createSentNotesReadFilter(final String identifier) {
+        return document(
+            identifier,
+            ResourceSnippetParameters.builder()
+                .requestHeaders(COOKIE_HEADER_DESCRIPTORS)
+                .queryParameters(Companion.getNOTES_REQUEST_PARAMETERS_DESCRIPTOR())
+                .responseFields(Companion.getSENT_NOTES_RESPONSE_FIELDS())
+                .tag(TAG)
+                .summary(NOTE_DETAIL_SUMMARY)
+                .description(NOTE_DETAIL_DESCRIPTION)
+                .privateResource(false)
+                .deprecated(false),
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            snippets -> {
+                List.of(
+                    requestCookies(TOKEN_COOKIE_DESCRIPTORS),
+                    queryParameters(Companion.getNOTES_REQUEST_PARAMETERS_DESCRIPTOR()),
+                    responseFields(Companion.getSENT_NOTES_RESPONSE_FIELDS().stream().toList()),
+                    responseFields(Arrays.stream(ERROR_RESPONSE).toList())
+                );
+            }
+        );
+    }
+
+    public static RestDocumentationFilter createReceivedNotesReadFilter(final String identifier) {
+        return document(
+            identifier,
+            ResourceSnippetParameters.builder()
+                .requestHeaders(COOKIE_HEADER_DESCRIPTORS)
+                .queryParameters(Companion.getNOTES_REQUEST_PARAMETERS_DESCRIPTOR())
+                .responseFields(Companion.getRECEIVED_NOTES_RESPONSE_FIELDS())
+                .tag(TAG)
+                .summary(NOTE_DETAIL_SUMMARY)
+                .description(NOTE_DETAIL_DESCRIPTION)
+                .privateResource(false)
+                .deprecated(false),
+            preprocessRequest(prettyPrint()),
+            preprocessResponse(prettyPrint()),
+            snippets -> {
+                List.of(
+                    requestCookies(TOKEN_COOKIE_DESCRIPTORS),
+                    queryParameters(Companion.getNOTES_REQUEST_PARAMETERS_DESCRIPTOR()),
+                    responseFields(Companion.getRECEIVED_NOTES_RESPONSE_FIELDS().stream().toList()),
                     responseFields(Arrays.stream(ERROR_RESPONSE).toList())
                 );
             }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/note/documentationtest/snippet/NoteSnippet.kt
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/note/documentationtest/snippet/NoteSnippet.kt
@@ -9,8 +9,10 @@ import org.springframework.restdocs.payload.RequestFieldsSnippet
 import org.springframework.restdocs.payload.ResponseFieldsSnippet
 import org.springframework.restdocs.request.ParameterDescriptor
 import org.springframework.restdocs.request.PathParametersSnippet
+import org.springframework.restdocs.request.QueryParametersSnippet
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import project.dailyge.app.common.SnippetUtils.getAttribute
 import project.dailyge.app.core.note.presentation.request.NoteCreateRequest
 
@@ -29,6 +31,11 @@ interface NoteSnippet {
                 .attributes(getAttribute(NoteCreateRequest::class.java, "sendAt"))
         )
 
+        val NOTES_REQUEST_PARAMETERS_DESCRIPTOR: Array<ParameterDescriptor> = arrayOf(
+            parameterWithName("index").description("다음 쪽지 Index").optional(),
+            parameterWithName("size").description("쪽지 개수")
+        )
+
         val NOTE_ID_PATH_PARAMETER_DESCRIPTORS: ParameterDescriptor =
             parameterWithName("noteId").description("Note ID")
 
@@ -42,6 +49,7 @@ interface NoteSnippet {
             fieldWithPath("data.noteId").type(JsonFieldType.NUMBER).description("Note ID"),
             fieldWithPath("data.title").type(JsonFieldType.STRING).description("쪽지 제목"),
             fieldWithPath("data.content").type(JsonFieldType.STRING).description("쪽지 내용"),
+            fieldWithPath("data.sentAt").type(JsonFieldType.STRING).description("보낸 날짜"),
             fieldWithPath("data.read").type(JsonFieldType.BOOLEAN).description("읽음 유무"),
             fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
             fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
@@ -51,6 +59,32 @@ interface NoteSnippet {
             fieldWithPath("data.noteId").type(JsonFieldType.NUMBER).description("Note ID"),
             fieldWithPath("data.title").type(JsonFieldType.STRING).description("쪽지 제목"),
             fieldWithPath("data.content").type(JsonFieldType.STRING).description("쪽지 내용"),
+            fieldWithPath("data.sentAt").type(JsonFieldType.STRING).description("보낸 날짜"),
+            fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+            fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+        )
+
+        val SENT_NOTES_RESPONSE_FIELDS: List<FieldDescriptor> = listOf(
+            fieldWithPath("data.data[].noteId").type(JsonFieldType.NUMBER).description("Note ID"),
+            fieldWithPath("data.data[].title").type(JsonFieldType.STRING).description("쪽지 제목"),
+            fieldWithPath("data.data[].content").type(JsonFieldType.STRING).description("쪽지 내용"),
+            fieldWithPath("data.data[].sentAt").type(JsonFieldType.STRING).description("보낸 날짜"),
+            fieldWithPath("data.data[].read").type(JsonFieldType.BOOLEAN).description("읽음 유무"),
+            fieldWithPath("data.totalCount").type(JsonFieldType.NUMBER).description("현재 페이지의 총 쪽지 개수"),
+            fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
+            fieldWithPath("data.size").type(JsonFieldType.NUMBER).description("요청된 쪽지 개수"),
+            fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
+            fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
+        )
+
+        val RECEIVED_NOTES_RESPONSE_FIELDS: List<FieldDescriptor> = listOf(
+            fieldWithPath("data.data[].noteId").type(JsonFieldType.NUMBER).description("Note ID"),
+            fieldWithPath("data.data[].title").type(JsonFieldType.STRING).description("쪽지 제목"),
+            fieldWithPath("data.data[].content").type(JsonFieldType.STRING).description("쪽지 내용"),
+            fieldWithPath("data.data[].sentAt").type(JsonFieldType.STRING).description("보낸 날짜"),
+            fieldWithPath("data.totalCount").type(JsonFieldType.NUMBER).description("현재 페이지의 총 쪽지 개수"),
+            fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN).description("다음 페이지 여부"),
+            fieldWithPath("data.size").type(JsonFieldType.NUMBER).description("요청된 쪽지 개수"),
             fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답 코드"),
             fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지")
         )
@@ -64,5 +98,8 @@ interface NoteSnippet {
         val RECEIVED_NOTE_DETAIL_READ_RESPONSE_FIELDS_RESPONSE_SNIPPET: ResponseFieldsSnippet = responseFields(
             RECEIVED_NOTE_DETAIL_READ_RESPONSE_FIELDS
         )
+        val NOTE_CURSOR_REQUEST_PARAMETER_SNIPPET: QueryParametersSnippet = queryParameters(NOTES_REQUEST_PARAMETERS_DESCRIPTOR.toList())
+        val SENT_NOTE_RESPONSE_SNIPPET: ResponseFieldsSnippet = responseFields(SENT_NOTES_RESPONSE_FIELDS)
+        val RECEIVED_NOTE_RESPONSE_SNIPPET: ResponseFieldsSnippet = responseFields(RECEIVED_NOTES_RESPONSE_FIELDS)
     }
 }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/note/integrationtest/NoteDeleteIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/note/integrationtest/NoteDeleteIntegrationTest.java
@@ -59,7 +59,7 @@ class NoteDeleteIntegrationTest extends DatabaseTestBase {
 
         // then: 발신자가 쪽지 조회
         assertDoesNotThrow(() ->
-            noteReadService.findSentNoteById(dailygeUser, newNoteId)
+            noteReadService.findSentNotesById(dailygeUser, newNoteId)
         );
     }
 
@@ -75,7 +75,7 @@ class NoteDeleteIntegrationTest extends DatabaseTestBase {
         noteWriteService.deleteSentNoteById(dailygeUser, newNoteId);
 
         // then: 발신자가 삭제된 쪽지 조회
-        assertThatThrownBy(() -> noteReadService.findSentNoteById(dailygeUser, newNoteId))
+        assertThatThrownBy(() -> noteReadService.findSentNotesById(dailygeUser, newNoteId))
             .isInstanceOf(NoteTypeException.class)
             .hasMessage(NOTE_NOT_FOUND.message());
     }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/note/integrationtest/NoteReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/note/integrationtest/NoteReadIntegrationTest.java
@@ -7,11 +7,11 @@ import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import project.dailyge.api.CursorPagingResponse;
 import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.UN_AUTHORIZED;
 import project.dailyge.app.common.DatabaseTestBase;
 import project.dailyge.app.common.exception.CommonException;
@@ -22,12 +22,14 @@ import static project.dailyge.app.core.note.exception.NoteCodeAndMessage.NOTE_NO
 import project.dailyge.app.core.note.exception.NoteTypeException;
 import project.dailyge.app.core.note.facade.NoteFacade;
 import project.dailyge.app.paging.Cursor;
+import static project.dailyge.app.paging.Cursor.createCursor;
 import static project.dailyge.app.test.note.fixture.NoteCommandFixture.createNoteCommand;
 import project.dailyge.common.ratelimiter.RateLimiterWriteService;
 import project.dailyge.entity.note.NoteJpaEntity;
 import project.dailyge.entity.user.Role;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @DisplayName("[IntegrationTest] 쪽지 조회 통합 테스트")
 class NoteReadIntegrationTest extends DatabaseTestBase {
@@ -161,18 +163,18 @@ class NoteReadIntegrationTest extends DatabaseTestBase {
         final LocalDateTime sentAt = LocalDateTime.of(2024, 10, 11, 13, 0);
         final NoteCreateCommand command = createNoteCommand(dailygeUser, sentAt);
         noteFacade.save(dailygeUser, command, 30);
-        final Cursor cursor = Cursor.createCursor(null, 10);
+        final Cursor cursor = createCursor(null, 10);
 
-        final CursorPagingResponse<NoteJpaEntity> findNote = noteReadService.findSentNotesById(dailygeUser, cursor);
-        assertTrue(findNote.getSize() > 0);
+        final List<NoteJpaEntity> findNote = noteReadService.findSentNotesById(dailygeUser, cursor);
+        assertFalse(findNote.isEmpty());
     }
 
     @Test
     @DisplayName("Cursor로 보낸 쪽지를 조회할 때, 쪽지가 존재하지 않으면 size가 0이다.")
     void whenSearchSentNotesWithCursorThenResultSizeShouldBeOver0() {
-        final Cursor cursor = Cursor.createCursor(null, 10);
-        final CursorPagingResponse<NoteJpaEntity> findNote = noteReadService.findSentNotesById(dailygeUser, cursor);
-        assertEquals(0, findNote.getTotalCount());
+        final Cursor cursor = createCursor(null, 10);
+        final List<NoteJpaEntity> findNote = noteReadService.findSentNotesById(dailygeUser, cursor);
+        assertEquals(0, findNote.size());
     }
 
     @Test
@@ -181,10 +183,10 @@ class NoteReadIntegrationTest extends DatabaseTestBase {
         final LocalDateTime sentAt = LocalDateTime.of(2024, 10, 11, 13, 0);
         final NoteCreateCommand command = createNoteCommand(dailygeUser, sentAt);
         final Long newNoteId = noteFacade.save(dailygeUser, command, 30);
-        final Cursor cursor = Cursor.createCursor(newNoteId + 1, 10);
+        final Cursor cursor = createCursor(newNoteId + 1, 10);
 
-        final CursorPagingResponse<NoteJpaEntity> findNote = noteReadService.findSentNotesById(dailygeUser, cursor);
-        assertTrue(findNote.getSize() > 0);
+        final List<NoteJpaEntity> findNote = noteReadService.findSentNotesById(dailygeUser, cursor);
+        assertFalse(findNote.isEmpty());
     }
 
     @Test
@@ -193,10 +195,10 @@ class NoteReadIntegrationTest extends DatabaseTestBase {
         final LocalDateTime sentAt = LocalDateTime.of(2024, 10, 11, 13, 0);
         final NoteCreateCommand command = createNoteCommand(dailygeUser, sentAt);
         noteFacade.save(dailygeUser, command, 30);
-        final Cursor cursor = Cursor.createCursor(null, 10);
+        final Cursor cursor = createCursor(null, 10);
 
-        final CursorPagingResponse<NoteJpaEntity> findNote = noteReadService.findReceivedNotesById(receivedDailygeUser, cursor);
-        assertTrue(findNote.getSize() > 0);
+        final List<NoteJpaEntity> findNote = noteReadService.findReceivedNotesById(receivedDailygeUser, cursor);
+        assertFalse(findNote.isEmpty());
     }
 
     @Test
@@ -205,17 +207,17 @@ class NoteReadIntegrationTest extends DatabaseTestBase {
         final LocalDateTime sentAt = LocalDateTime.of(2024, 10, 11, 13, 0);
         final NoteCreateCommand command = createNoteCommand(dailygeUser, sentAt);
         final Long newNoteId = noteFacade.save(dailygeUser, command, 30);
-        final Cursor cursor = Cursor.createCursor(newNoteId + 1, 10);
+        final Cursor cursor = createCursor(newNoteId + 1, 10);
 
-        final CursorPagingResponse<NoteJpaEntity> findNote = noteReadService.findReceivedNotesById(receivedDailygeUser, cursor);
-        assertTrue(findNote.getSize() > 0);
+        final List<NoteJpaEntity> findNote = noteReadService.findReceivedNotesById(receivedDailygeUser, cursor);
+        assertFalse(findNote.isEmpty());
     }
 
     @Test
     @DisplayName("Cursor로 받은 쪽지를 조회할 때, 쪽지가 존재하지 않으면 size가 0이다.")
     void whenSearchReceivedNotesWithCursorThenResultSizeShouldBeOver0() {
-        final Cursor cursor = Cursor.createCursor(null, 10);
-        final CursorPagingResponse<NoteJpaEntity> findNote = noteReadService.findSentNotesById(dailygeUser, cursor);
-        assertEquals(0, findNote.getTotalCount());
+        final Cursor cursor = createCursor(null, 10);
+        final List<NoteJpaEntity> findNote = noteReadService.findSentNotesById(dailygeUser, cursor);
+        assertEquals(0, findNote.size());
     }
 }

--- a/dailyge-api/src/test/java/project/dailyge/app/test/note/integrationtest/NoteReadIntegrationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/note/integrationtest/NoteReadIntegrationTest.java
@@ -123,7 +123,7 @@ class NoteReadIntegrationTest extends DatabaseTestBase {
         final Long newNoteId = noteFacade.save(dailygeUser, command, 30);
         final DailygeUser invalidDailygeUser = new DailygeUser(Long.MAX_VALUE, Role.NORMAL);
 
-        assertThatThrownBy(() -> noteReadService.findSentNoteById(invalidDailygeUser, newNoteId))
+        assertThatThrownBy(() -> noteReadService.findSentNotesById(invalidDailygeUser, newNoteId))
             .isInstanceOf(CommonException.class)
             .hasMessage(UN_AUTHORIZED.message());
     }
@@ -136,7 +136,7 @@ class NoteReadIntegrationTest extends DatabaseTestBase {
         noteFacade.save(dailygeUser, command, 30);
         final Long invalidNoteId = Long.MAX_VALUE;
 
-        assertThatThrownBy(() -> noteReadService.findSentNoteById(dailygeUser, invalidNoteId))
+        assertThatThrownBy(() -> noteReadService.findSentNotesById(dailygeUser, invalidNoteId))
             .isInstanceOf(NoteTypeException.class)
             .hasMessage(NOTE_NOT_FOUND.message());
     }
@@ -148,7 +148,7 @@ class NoteReadIntegrationTest extends DatabaseTestBase {
         final NoteCreateCommand command = createNoteCommand(dailygeUser, sentAt);
         final Long newNoteId = noteFacade.save(dailygeUser, command, 30);
 
-        final NoteJpaEntity findNote = noteReadService.findSentNoteById(dailygeUser, newNoteId);
+        final NoteJpaEntity findNote = noteReadService.findSentNotesById(dailygeUser, newNoteId);
         assertNotNull(findNote);
     }
 }

--- a/modules/api/src/main/kotlin/project/dailyge/api/CursorPagingResponse.kt
+++ b/modules/api/src/main/kotlin/project/dailyge/api/CursorPagingResponse.kt
@@ -1,0 +1,9 @@
+package project.dailyge.api
+
+class CursorPagingResponse<T>(
+    _data: List<T>,
+    val size: Int,
+) {
+    val data: List<T> = if (_data.size > size) _data.take(size - 1) else _data
+    val hasNext: Boolean = _data.size > size
+}

--- a/modules/api/src/main/kotlin/project/dailyge/api/CursorPagingResponse.kt
+++ b/modules/api/src/main/kotlin/project/dailyge/api/CursorPagingResponse.kt
@@ -5,5 +5,6 @@ class CursorPagingResponse<T>(
     val size: Int,
 ) {
     val data: List<T> = if (_data.size > size) _data.take(size - 1) else _data
+    val totalCount = data.size
     val hasNext: Boolean = _data.size > size
 }

--- a/storage/rdb/src/main/java/project/dailyge/entity/note/NoteEntityReadRepository.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/note/NoteEntityReadRepository.java
@@ -10,5 +10,13 @@ public interface NoteEntityReadRepository {
 
     Optional<NoteJpaEntity> findSentNoteById(Long noteId);
 
+    List<NoteJpaEntity> findSentNotesById(Long userId, Integer size);
+
+    List<NoteJpaEntity> findSentNotesById(Long userId, Long index, Integer size);
+
+    List<NoteJpaEntity> findReceivedNotesById(Long userId, Integer size);
+
+    List<NoteJpaEntity> findReceivedNotesById(Long userId, Long index, Integer size);
+
     List<NoteJpaEntity> findAll();
 }

--- a/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
@@ -15,10 +15,10 @@ import project.dailyge.entity.BaseEntity;
 @Entity(name = "users")
 public class UserJpaEntity extends BaseEntity {
 
-    private static final int MAX_NICKNAME_LENGTH = 20;
+    private static final int MAX_NICKNAME_LENGTH = 24;
     private static final int MAX_PROFILE_IMAGE_URL_LENGTH = 2000;
-    private static final String EMAIL_PATTERN = "^[0-9a-zA-Z](?:[-_.]?[0-9a-zA-Z]){0,39}@gmail\\.com$";
-    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣_-]{3,20}$");
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[0-9a-zA-Z]+(?:[._-]?[0-9a-zA-Z]+)*@gmail\\.com$");
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣._-]{3,24}$");
     private static final String OVER_MAX_NICKNAME_LENGTH_ERROR_MESSAGE = "입력 가능한 최대 닉네임 길이를 초과했습니다.";
     private static final String INVALID_EMAIL_ERROR_MESSAGE = "유효하지 않는 이메일 형식입니다.";
     private static final String OVER_MAX_PROFILE_IMAGE_URL_ERROR_MESSAGE = "입력 가능한 최대 URL 길이를 초과했습니다.";
@@ -150,7 +150,7 @@ public class UserJpaEntity extends BaseEntity {
     }
 
     private void validateEmail(final String email) {
-        if (!Pattern.matches(EMAIL_PATTERN, email)) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
             throw new IllegalArgumentException(INVALID_EMAIL_ERROR_MESSAGE);
         }
     }

--- a/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
@@ -7,17 +7,18 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import project.dailyge.entity.BaseEntity;
+
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.regex.Pattern;
-import project.dailyge.entity.BaseEntity;
 
 @Entity(name = "users")
 public class UserJpaEntity extends BaseEntity {
 
     private static final int MAX_NICKNAME_LENGTH = 24;
     private static final int MAX_PROFILE_IMAGE_URL_LENGTH = 2000;
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[0-9a-zA-Z]+(?:[._-]?[0-9a-zA-Z]+)*@gmail\\.com$");
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[0-9a-zA-Z._-]+@gmail\\.com$");
     private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣._-]{3,24}$");
     private static final String OVER_MAX_NICKNAME_LENGTH_ERROR_MESSAGE = "입력 가능한 최대 닉네임 길이를 초과했습니다.";
     private static final String INVALID_EMAIL_ERROR_MESSAGE = "유효하지 않는 이메일 형식입니다.";

--- a/storage/rdb/src/main/kotlin/project/dailyge/entity/note/NoteJpaEntity.kt
+++ b/storage/rdb/src/main/kotlin/project/dailyge/entity/note/NoteJpaEntity.kt
@@ -72,6 +72,8 @@ class NoteJpaEntity(
     val isRead: Boolean
         get() = _isRead
 
+    val sentAtAsString: String = sentAt.toString()
+
     val readAt: LocalDateTime?
         get() = _readAt
 

--- a/storage/rdb/src/test/java/project/dailyge/entity/test/user/UserJpaEntityUnitTest.java
+++ b/storage/rdb/src/test/java/project/dailyge/entity/test/user/UserJpaEntityUnitTest.java
@@ -7,12 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static project.dailyge.entity.user.Role.NORMAL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import static project.dailyge.entity.user.Role.NORMAL;
 import project.dailyge.entity.user.UserJpaEntity;
 
 @DisplayName("[UnitTest] UserJPAEntity 단위 테스트")
@@ -56,7 +56,7 @@ class UserJpaEntityUnitTest {
     @Test
     @DisplayName("허용 가능한 닉네임 길이를 초과하면, IllegalArgumentException이 발생한다.")
     void whenMaxLengthOverNicknameThenIllegalArgumentExceptionShouldBeHappen() {
-        final String overLengthNickname = "n".repeat(21);
+        final String overLengthNickname = "n".repeat(25);
 
         assertThatThrownBy(() -> new UserJpaEntity(1L, overLengthNickname, EMAIL))
             .isExactlyInstanceOf(IllegalArgumentException.class)
@@ -92,7 +92,9 @@ class UserJpaEntityUnitTest {
 
     @ParameterizedTest
     @DisplayName("닉네임이 허용 길이 초과일 경우 IllegalArgumentException이 발생한다.")
-    @ValueSource(strings = {"abcdefghijklmnopqrstu", "123456789012345678901", "niㄹffffffckname_too_long"})
+    @ValueSource(strings = {
+        "abcdefghijklmnopqrstsadfdasfadsfasfsfu", "1sfadsfasfsf23456789012345678901", "niㄹffsfadsfasfsfsfadsfasfsfffffckname_too_long"}
+    )
     void whenNicknameExceedsMaxLengthThenIllegalArgumentExceptionShouldBeHappen(final String nickname) {
         assertThatThrownBy(() -> new UserJpaEntity(1L, nickname, EMAIL))
             .isExactlyInstanceOf(IllegalArgumentException.class)

--- a/storage/rdb/src/test/kotlin/project/dailyge/entity/test/note/NoteUnitTest.kt
+++ b/storage/rdb/src/test/kotlin/project/dailyge/entity/test/note/NoteUnitTest.kt
@@ -33,6 +33,7 @@ class NoteUnitTest : DescribeSpec({
                 note.senderDeleted shouldBe false
                 note.receiverDeleted shouldBe false
                 note.sentAt shouldBe fixedSentAt
+                note.sentAtAsString shouldNotBe null
                 note.readAt shouldBe null
             }
 


### PR DESCRIPTION
## 📝 작업 내용

수신자, 발신자의 쪽지 목록 조회 API를 개발했습니다.

- [x] 수신자, 발신자 쪽지 목록 조회 API 개발
- [x] 수신, 발신 메시지 응답에 날짜 필드 추가
- [x] 단위, 통합, 문서화 테스트 작성
- [x] 깨진 테스트 복구, 테스트 케이스 보강  

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-388)
