### PR TITLE
[DLG-387] 인증에 관련된 쿠키들의 명칭을 변경한다.

### DIFF
--- a/admin-api/src/main/java/project/dailyge/app/common/configuration/web/AuthArgumentResolver.java
+++ b/admin-api/src/main/java/project/dailyge/app/common/configuration/web/AuthArgumentResolver.java
@@ -45,7 +45,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         try {
             final Cookies cookies = new Cookies(request.getCookies());
-            final String accessToken = cookies.getValueByKey("Access-Token");
+            final String accessToken = cookies.getValueByKey("dg_sess");
             final Long userId = tokenProvider.getUserId(accessToken);
             if (userId == null) {
                 throw CommonException.from(UN_AUTHORIZED);

--- a/admin-api/src/test/java/project/dailyge/app/common/DatabaseTestBase.java
+++ b/admin-api/src/test/java/project/dailyge/app/common/DatabaseTestBase.java
@@ -88,7 +88,7 @@ public abstract class DatabaseTestBase {
     }
 
     protected Cookie getAccessTokenCookie() {
-        return new Cookie.Builder("Access-Token", accessToken).build();
+        return new Cookie.Builder("dg_sess", accessToken).build();
     }
 
     protected UserJpaEntity persist(final UserJpaEntity user) {

--- a/admin-api/src/test/java/project/dailyge/app/test/common/AuthArgumentResolverTest.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/common/AuthArgumentResolverTest.java
@@ -57,7 +57,7 @@ class AuthArgumentResolverTest {
         final UserJpaEntity user = UserFixture.createUser(1L);
         final DailygeToken token = tokenProvider.createToken(user.getId());
         final Cookie[] cookies = new Cookie[1];
-        cookies[0] = new Cookie("Access-Token", token.accessToken());
+        cookies[0] = new Cookie("dg_sess", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);
         when(userCacheReadService.findById(user.getId()))
             .thenReturn(new UserCache(
@@ -88,7 +88,7 @@ class AuthArgumentResolverTest {
         final UserJpaEntity expectedUser = UserFixture.createUser(validUserId);
         final DailygeToken token = tokenProvider.createToken(expectedUser.getId());
         final Cookie[] cookies = new Cookie[1];
-        cookies[0] = new Cookie("Access-Token", token.accessToken());
+        cookies[0] = new Cookie("dg_sess", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);
         when(userCacheReadService.findById(validUserId))
             .thenReturn(new UserCache(

--- a/admin-api/src/test/java/project/dailyge/app/test/notice/documentationtest/NoticeCreateDocumentation.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/notice/documentationtest/NoticeCreateDocumentation.java
@@ -49,7 +49,7 @@ class NoticeCreateDocumentation extends DatabaseTestBase {
         userCacheWriteService.save(adminUser);
         token = tokenProvider.createToken(ADMIN_ID);
         request = new NoticeCreateRequest("공지사항 제목", CONTENT, UPDATE);
-        adminCookie = new Cookie.Builder("Access-Token", token.accessToken()).build();
+        adminCookie = new Cookie.Builder("dg_sess", token.accessToken()).build();
     }
 
     @Test

--- a/admin-api/src/test/java/project/dailyge/app/test/notice/documentationtest/snippet/NoticeSnippet.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/notice/documentationtest/snippet/NoticeSnippet.java
@@ -21,7 +21,7 @@ public interface NoticeSnippet {
     String tag = "notice";
 
     CookieDescriptor[] NOTICE_ACCESS_TOKEN_COOKIE_DESCRIPTOR = {
-        cookieWithName("Access-Token").description("사용자 토큰 쿠키")
+        cookieWithName("dg_sess").description("사용자 토큰 쿠키")
     };
 
     RequestCookiesSnippet NOTICE_ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(NOTICE_ACCESS_TOKEN_COOKIE_DESCRIPTOR);

--- a/admin-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserBlacklistCreateDocumentation.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserBlacklistCreateDocumentation.java
@@ -48,7 +48,7 @@ class UserBlacklistCreateDocumentation extends DatabaseTestBase {
         userCacheWriteService.save(admin);
         token = tokenProvider.createToken(ADMIN_ID);
         request = new UserBlacklistCreateRequest("accessToken");
-        adminCookie = new Cookie.Builder("Access-Token", token.accessToken()).build();
+        adminCookie = new Cookie.Builder("dg_sess", token.accessToken()).build();
     }
 
     @Test

--- a/admin-api/src/test/java/project/dailyge/app/test/user/documentationtest/snippet/UserSnippet.java
+++ b/admin-api/src/test/java/project/dailyge/app/test/user/documentationtest/snippet/UserSnippet.java
@@ -26,7 +26,7 @@ public interface UserSnippet {
     String tag = "user";
 
     CookieDescriptor[] USER_BLACKLIST_ACCESS_TOKEN_COOKIE_DESCRIPTOR = {
-        cookieWithName("Access-Token").description("사용자 토큰 쿠키")
+        cookieWithName("dg_sess").description("사용자 토큰 쿠키")
     };
 
     RequestCookiesSnippet USER_BLACKLIST_ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(USER_BLACKLIST_ACCESS_TOKEN_COOKIE_DESCRIPTOR);

--- a/buildSrc/src/main/kotlin/CommonUtils.kt
+++ b/buildSrc/src/main/kotlin/CommonUtils.kt
@@ -14,7 +14,7 @@ fun addAuthOption(content: String): String {
             JsonObject().apply {
                 addProperty("type", "apiKey")
                 addProperty("in", "cookie")
-                addProperty("name", "Access-Token")
+                addProperty("name", "dg_sess")
             }
         )
     }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/auth/AuthArgumentResolver.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/auth/AuthArgumentResolver.java
@@ -50,7 +50,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         try {
             final Cookies cookies = new Cookies(request.getCookies());
-            final String accessToken = cookies.getValueByKey("Access-Token");
+            final String accessToken = cookies.getValueByKey("dg_sess");
             final Long userId = tokenProvider.getUserId(accessToken);
             if (userId == null) {
                 throw CommonException.from(INVALID_USER_ID);

--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/auth/DailygeToken.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/auth/DailygeToken.java
@@ -9,8 +9,8 @@ public record DailygeToken(
     int refreshTokenMaxAge
 ) {
 
-    private static final String ACCESS_TOKEN = "Access-Token";
-    private static final String REFRESH_TOKEN = "Refresh-Token";
+    private static final String ACCESS_TOKEN = "dg_sess";
+    private static final String REFRESH_TOKEN = "dg_res";
 
     public String getAccessTokenCookie(final String env) {
         return createResponseCookie(ACCESS_TOKEN, accessToken, "/", accessTokenMaxAge, true, env);

--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/auth/LoginInterceptor.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/auth/LoginInterceptor.java
@@ -56,7 +56,7 @@ public class LoginInterceptor implements HandlerInterceptor {
             if (!cookies.isLoggedIn()) {
                 return true;
             }
-            final String accessToken = cookies.getValueByKey("Access-Token");
+            final String accessToken = cookies.getValueByKey("dg_sess");
             final Long userId = tokenProvider.getUserId(accessToken);
             if (!userCacheReadService.existsById(userId)) {
                 return true;
@@ -85,7 +85,7 @@ public class LoginInterceptor implements HandlerInterceptor {
                 return true;
             }
             final Cookies cookies = new Cookies(request.getCookies());
-            final String refreshToken = cookies.getValueByKey("Refresh-Token");
+            final String refreshToken = cookies.getValueByKey("dg_res");
             if (!tokenManager.getRefreshToken(userId).equals(refreshToken)) {
                 return true;
             }
@@ -107,7 +107,7 @@ public class LoginInterceptor implements HandlerInterceptor {
         final Map<String, String> bodyMap = new HashMap<>();
         final String referer = request.getHeader("referer");
         bodyMap.put("url", referer == null ? "/" : referer);
-        response.addCookie(createCookie("Access-Token", accessToken, "/", 900));
+        response.addCookie(createCookie("dg_sess", accessToken, "/", 900));
         response.setStatus(BAD_REQUEST.code());
         response.setContentType(APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(UTF_8.name());

--- a/dailyge-api/src/main/java/project/dailyge/app/core/common/web/Cookies.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/common/web/Cookies.java
@@ -20,7 +20,7 @@ public final class Cookies {
     }
 
     public boolean isLoggedIn() {
-        final String loggedIn = getValueByKey("Logged-In");
+        final String loggedIn = getValueByKey("logged_in");
         return loggedIn != null && loggedIn.equals("yes");
     }
 

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/presentation/LoginApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/presentation/LoginApi.java
@@ -48,7 +48,7 @@ public class LoginApi {
         final HttpHeaders headers = new HttpHeaders();
         headers.add(SET_COOKIE, dailygeToken.getAccessTokenCookie(env));
         headers.add(SET_COOKIE, dailygeToken.getRefreshTokenCookie(env));
-        headers.add(SET_COOKIE, createResponseCookie("Logged-In", "yes", "/", dailygeToken.accessTokenMaxAge(), false, env));
+        headers.add(SET_COOKIE, createResponseCookie("logged_in", "yes", "/", dailygeToken.accessTokenMaxAge(), false, env));
         return ApiResponse.from(OK, headers, null);
     }
 
@@ -56,9 +56,9 @@ public class LoginApi {
     public ApiResponse<Void> logout(@LoginUser final DailygeUser dailygeUser) {
         userFacade.logout(dailygeUser.getUserId());
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(SET_COOKIE, clearResponseCookie("Access-Token", true));
-        headers.add(SET_COOKIE, clearResponseCookie("Refresh-Token", true));
-        headers.add(SET_COOKIE, clearResponseCookie("Logged-In", false));
+        headers.add(SET_COOKIE, clearResponseCookie("dg_sess", true));
+        headers.add(SET_COOKIE, clearResponseCookie("dg_res", true));
+        headers.add(SET_COOKIE, clearResponseCookie("logged_in", false));
         return ApiResponse.from(OK, headers, null);
     }
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/user/presentation/UserDeleteApi.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/user/presentation/UserDeleteApi.java
@@ -31,9 +31,9 @@ public class UserDeleteApi {
         dailygeUser.validateAuth(userId);
         userFacade.delete(userId);
         final HttpHeaders headers = new HttpHeaders();
-        headers.add(SET_COOKIE, clearResponseCookie("Access-Token", true));
-        headers.add(SET_COOKIE, clearResponseCookie("Refresh-Token", true));
-        headers.add(SET_COOKIE, clearResponseCookie("Logged-In", false));
+        headers.add(SET_COOKIE, clearResponseCookie("dg_sess", true));
+        headers.add(SET_COOKIE, clearResponseCookie("dg_res", true));
+        headers.add(SET_COOKIE, clearResponseCookie("logged_in", false));
         return ApiResponse.from(NO_CONTENT, headers, null);
     }
 }

--- a/dailyge-api/src/test/java/project/dailyge/app/common/CommonSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/common/CommonSnippet.java
@@ -14,13 +14,13 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 public interface CommonSnippet {
 
     CookieDescriptor[] TOKEN_COOKIE_DESCRIPTORS = {
-        cookieWithName("Access-Token").description("인증 토큰")
+        cookieWithName("dg_sess").description("인증 토큰")
     };
 
     RequestCookiesSnippet ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(TOKEN_COOKIE_DESCRIPTORS);
 
     HeaderDescriptor[] COOKIE_HEADER_DESCRIPTORS = {
-        headerWithName("Cookie").description("Access-Token=인증 토큰")
+        headerWithName("Cookie").description("dg_sess=인증 토큰")
     };
 
     FieldDescriptor[] ERROR_RESPONSE = {

--- a/dailyge-api/src/test/java/project/dailyge/app/common/DatabaseTestBase.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/common/DatabaseTestBase.java
@@ -122,12 +122,12 @@ public abstract class DatabaseTestBase {
     }
 
     protected Cookie getAccessTokenCookie() {
-        return new Cookie.Builder("Access-Token", accessToken)
+        return new Cookie.Builder("dg_sess", accessToken)
             .build();
     }
 
     protected Cookie getNoteReceiverAccessTokenCookie() {
-        return new Cookie.Builder("Access-Token", noteReceiverAccessToken)
+        return new Cookie.Builder("dg_sess", noteReceiverAccessToken)
             .build();
     }
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/AuthArgumentResolverTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/AuthArgumentResolverTest.java
@@ -59,7 +59,7 @@ class AuthArgumentResolverTest {
         final UserJpaEntity user = UserFixture.createUser(1L);
         final DailygeToken token = tokenProvider.createToken(user.getId());
         final Cookie[] cookies = new Cookie[1];
-        cookies[0] = new Cookie("Access-Token", token.accessToken());
+        cookies[0] = new Cookie("dg_sess", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);
         when(userCacheReadService.findById(user.getId()))
             .thenReturn(new UserCache(
@@ -90,7 +90,7 @@ class AuthArgumentResolverTest {
         final UserJpaEntity expectedUser = UserFixture.createUser(validUserId);
         final DailygeToken token = tokenProvider.createToken(expectedUser.getId());
         final Cookie[] cookies = new Cookie[1];
-        cookies[0] = new Cookie("Access-Token", token.accessToken());
+        cookies[0] = new Cookie("dg_sess", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);
         when(userCacheReadService.findById(validUserId))
             .thenReturn(new UserCache(

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/CookieUtilsUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/CookieUtilsUnitTest.java
@@ -16,7 +16,7 @@ import static project.dailyge.app.common.utils.CookieUtils.createResponseCookie;
 @DisplayName("[UnitTest] CookieUtils 단위 테스트")
 class CookieUtilsUnitTest {
 
-    private static final String REFRESH_TOKEN = "Refresh-Token";
+    private static final String REFRESH_TOKEN = "dg_res";
     private static final String COOKIE_PATH = "/app";
     private static final long MAX_AGE = 86_400L;
     private static final String COOKIE_VALUE = "testValue";
@@ -41,7 +41,7 @@ class CookieUtilsUnitTest {
     void whenClearResponseCookieThenCorrectlyGenerated() {
         final String cookieString = CookieUtils.clearResponseCookie(REFRESH_TOKEN, true);
         assertAll(
-            () -> assertTrue(cookieString.contains("Refresh-Token=")),
+            () -> assertTrue(cookieString.contains("dg_res")),
             () -> assertTrue(cookieString.contains("Max-Age=0")),
             () -> assertTrue(cookieString.contains("Domain=.dailyge.com")),
             () -> assertTrue(cookieString.contains("Path=/")),
@@ -57,7 +57,7 @@ class CookieUtilsUnitTest {
             REFRESH_TOKEN, COOKIE_VALUE, COOKIE_PATH, MAX_AGE, true, "local"
         );
         assertAll(
-            () -> assertTrue(cookieString.contains("Refresh-Token=testValue")),
+            () -> assertTrue(cookieString.contains("dg_res=testValue")),
             () -> assertTrue(cookieString.contains("Max-Age=86400")),
             () -> assertTrue(cookieString.contains("Path=" + COOKIE_PATH)),
             () -> assertFalse(cookieString.contains("Domain="))
@@ -71,7 +71,7 @@ class CookieUtilsUnitTest {
             REFRESH_TOKEN, COOKIE_VALUE, COOKIE_PATH, MAX_AGE, true, "prod"
         );
         assertAll(
-            () -> assertTrue(cookieString.contains("Refresh-Token=testValue")),
+            () -> assertTrue(cookieString.contains("dg_res=testValue")),
             () -> assertTrue(cookieString.contains("Max-Age=86400")),
             () -> assertTrue(cookieString.contains("Domain=.dailyge.com")),
             () -> assertTrue(cookieString.contains("Path=" + COOKIE_PATH)),

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/CookiesUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/CookiesUnitTest.java
@@ -15,7 +15,7 @@ class CookiesUnitTest {
 
     private static final String KEY = "dailyge";
     private static final String VALUE = "good";
-    private static final String LOGGED_IN = "Logged-In";
+    private static final String LOGGED_IN = "logged_in";
     private Cookie[] cookie;
 
     @BeforeEach
@@ -60,7 +60,7 @@ class CookiesUnitTest {
     }
 
     @Test
-    @DisplayName("Logged-In이 비어있는 요청은, false를 반환한다.")
+    @DisplayName("logged_in이 비어있는 요청은, false를 반환한다.")
     void whenLoggedInIsEmptyThenResultShouldBeFalse() {
         final Cookie[] emtpyCookie = new Cookie[0];
         final Cookies cookies = new Cookies(emtpyCookie);

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/DailygeTokenUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/DailygeTokenUnitTest.java
@@ -25,7 +25,7 @@ class DailygeTokenUnitTest {
         final DailygeToken token = new DailygeToken(ACCESS_TOKEN_VALUE, REFRESH_TOKEN_VALUE, ACCESS_TOKEN_MAX_AGE, REFRESH_TOKEN_MAX_AGE);
         final String accessTokenCookie = token.getAccessTokenCookie(ENV_PROD);
         assertAll(
-            () -> assertTrue(accessTokenCookie.contains("Access-Token=accessTokenValue")),
+            () -> assertTrue(accessTokenCookie.contains("dg_sess=accessTokenValue")),
             () -> assertTrue(accessTokenCookie.contains("Max-Age=1800")),
             () -> assertTrue(accessTokenCookie.contains("Path=/")),
             () -> assertTrue(accessTokenCookie.contains("Secure")),
@@ -40,7 +40,7 @@ class DailygeTokenUnitTest {
         final DailygeToken token = new DailygeToken(ACCESS_TOKEN_VALUE, REFRESH_TOKEN_VALUE, ACCESS_TOKEN_MAX_AGE, REFRESH_TOKEN_MAX_AGE);
         final String refreshTokenCookie = token.getRefreshTokenCookie(ENV_PROD);
         assertAll(
-            () -> assertTrue(refreshTokenCookie.contains("Refresh-Token=refreshTokenValue")),
+            () -> assertTrue(refreshTokenCookie.contains("dg_res=refreshTokenValue")),
             () -> assertTrue(refreshTokenCookie.contains("Max-Age=2592000")),
             () -> assertTrue(refreshTokenCookie.contains("Path=/")),
             () -> assertTrue(refreshTokenCookie.contains("Secure")),
@@ -55,7 +55,7 @@ class DailygeTokenUnitTest {
         final DailygeToken token = new DailygeToken(ACCESS_TOKEN_VALUE, REFRESH_TOKEN_VALUE, ACCESS_TOKEN_MAX_AGE, REFRESH_TOKEN_MAX_AGE);
         final String accessTokenCookie = token.getAccessTokenCookie(ENV_LOCAL);
         assertAll(
-            () -> assertTrue(accessTokenCookie.contains("Access-Token=accessTokenValue")),
+            () -> assertTrue(accessTokenCookie.contains("dg_sess=accessTokenValue")),
             () -> assertTrue(accessTokenCookie.contains("Max-Age=1800")),
             () -> assertTrue(accessTokenCookie.contains("Path=/")),
             () -> assertFalse(accessTokenCookie.contains("Domain=")),
@@ -70,7 +70,7 @@ class DailygeTokenUnitTest {
         final DailygeToken token = new DailygeToken(ACCESS_TOKEN_VALUE, REFRESH_TOKEN_VALUE, ACCESS_TOKEN_MAX_AGE, REFRESH_TOKEN_MAX_AGE);
         final String refreshTokenCookie = token.getRefreshTokenCookie(ENV_LOCAL);
         assertAll(
-            () -> assertTrue(refreshTokenCookie.contains("Refresh-Token=refreshTokenValue")),
+            () -> assertTrue(refreshTokenCookie.contains("dg_res=refreshTokenValue")),
             () -> assertTrue(refreshTokenCookie.contains("Max-Age=2592000")),
             () -> assertTrue(refreshTokenCookie.contains("Path=/")),
             () -> assertFalse(refreshTokenCookie.contains("Domain=")),
@@ -94,8 +94,8 @@ class DailygeTokenUnitTest {
         final String accessTokenCookie = token.getAccessTokenCookie(ENV_PROD);
         final String refreshTokenCookie = token.getRefreshTokenCookie(ENV_PROD);
         assertAll(
-            () -> assertTrue(accessTokenCookie.contains("Access-Token=")),
-            () -> assertTrue(refreshTokenCookie.contains("Refresh-Token="))
+            () -> assertTrue(accessTokenCookie.contains("dg_sess=")),
+            () -> assertTrue(refreshTokenCookie.contains("dg_res="))
         );
     }
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/common/LoginInterceptorUnitTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/common/LoginInterceptorUnitTest.java
@@ -71,8 +71,8 @@ class LoginInterceptorUnitTest {
         final DailygeToken token = tokenProvider.createToken(user.getId());
 
         final Cookie[] cookies = new Cookie[2];
-        cookies[0] = new Cookie("Logged-In", "yes");
-        cookies[1] = new Cookie("Access-Token", token.accessToken());
+        cookies[0] = new Cookie("logged_in", "yes");
+        cookies[1] = new Cookie("dg_sess", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);
         when(userCacheReadService.existsById(user.getId())).thenReturn(true);
 
@@ -88,9 +88,9 @@ class LoginInterceptorUnitTest {
         final TokenProvider expiredTokenProvider = new TokenProvider(expiredJwtProperties, secretKeyManager);
         final DailygeToken expiredToken = expiredTokenProvider.createToken(user.getId());
         final Cookie[] cookies = new Cookie[3];
-        cookies[0] = new Cookie("Logged-In", "yes");
-        cookies[1] = new Cookie("Refresh-Token", token.refreshToken());
-        cookies[2] = new Cookie("Access-Token", expiredToken.accessToken());
+        cookies[0] = new Cookie("logged_in", "yes");
+        cookies[1] = new Cookie("dg_res", token.refreshToken());
+        cookies[2] = new Cookie("dg_sess", expiredToken.accessToken());
 
         when(request.getCookies()).thenReturn(cookies);
         when(userCacheReadService.existsById(user.getId()))
@@ -107,7 +107,7 @@ class LoginInterceptorUnitTest {
             .thenReturn(token.refreshToken());
 
         final boolean result = loginInterceptor.preHandle(request, response, null);
-        final Cookie accessTokencookie = response.getCookie("Access-Token");
+        final Cookie accessTokencookie = response.getCookie("dg_sess");
 
         assertFalse(result);
         assertNotEquals(cookies[1].getValue(), accessTokencookie.getValue());
@@ -120,9 +120,9 @@ class LoginInterceptorUnitTest {
         final UserJpaEntity user = createUser(1L);
         final DailygeToken expiredToken = expiredTokenProvider.createToken(user.getId());
         final Cookie[] cookies = new Cookie[3];
-        cookies[0] = new Cookie("Logged-In", "yes");
-        cookies[1] = new Cookie("Refresh-Token", expiredToken.refreshToken());
-        cookies[2] = new Cookie("Access-Token", expiredToken.accessToken());
+        cookies[0] = new Cookie("logged_in", "yes");
+        cookies[1] = new Cookie("dg_res", expiredToken.refreshToken());
+        cookies[2] = new Cookie("dg_sess", expiredToken.accessToken());
         when(request.getCookies()).thenReturn(cookies);
 
         assertTrue(loginInterceptor.preHandle(request, response, null));
@@ -135,7 +135,7 @@ class LoginInterceptorUnitTest {
         final DailygeToken token = tokenProvider.createToken(user.getId());
 
         final Cookie[] cookies = new Cookie[1];
-        cookies[0] = new Cookie("Access-Token", token.accessToken());
+        cookies[0] = new Cookie("dg_sess", token.accessToken());
         when(request.getCookies()).thenReturn(cookies);
         when(userCacheReadService.existsById(user.getId())).thenReturn(true);
 

--- a/dailyge-api/src/test/java/project/dailyge/app/test/coupon/documentationtest/snippet/CouponSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/coupon/documentationtest/snippet/CouponSnippet.java
@@ -11,7 +11,7 @@ public interface CouponSnippet {
     String TAG = "Coupon";
     String identifier = "{class_name}/{method_name}/";
     CookieDescriptor[] COUPON_TOKEN_COOKIE_DESCRIPTORS = {
-        cookieWithName("Access-Token").description("인증 토큰")
+        cookieWithName("dg_sess").description("인증 토큰")
     };
 
     FieldDescriptor[] COUPON_CREATE_RESPONSE_FIELDS = {

--- a/dailyge-api/src/test/java/project/dailyge/app/test/monthlygoal/documentationtest/snippet/MonthlyGoalSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/monthlygoal/documentationtest/snippet/MonthlyGoalSnippet.java
@@ -27,7 +27,7 @@ public interface MonthlyGoalSnippet {
     String identifier = "{class_name}/{method_name}/";
 
     CookieDescriptor[] MONTHLY_GOAL_TOKEN_COOKIE_DESCRIPTORS = {
-        cookieWithName("Access-Token").description("인증 토큰")
+        cookieWithName("dg_sess").description("인증 토큰")
     };
 
     RequestCookiesSnippet MONTHLY_GOAL_ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(MONTHLY_GOAL_TOKEN_COOKIE_DESCRIPTORS);

--- a/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/documentationtest/snippet/RetrospectSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/retrospect/documentationtest/snippet/RetrospectSnippet.java
@@ -30,7 +30,7 @@ public interface RetrospectSnippet {
     String identifier = "{class_name}/{method_name}/";
 
     CookieDescriptor[] TOKEN_COOKIE_DESCRIPTORS = {
-        cookieWithName("Access-Token").description("인증 토큰")
+        cookieWithName("dg_sess").description("인증 토큰")
     };
 
     ParameterDescriptor[] RETROSPECT_ID_PATH_PARAMETER_DESCRIPTORS = {

--- a/dailyge-api/src/test/java/project/dailyge/app/test/task/documentationtest/snippet/TaskSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/task/documentationtest/snippet/TaskSnippet.java
@@ -35,7 +35,7 @@ public interface TaskSnippet {
     String identifier = "{class_name}/{method_name}/";
 
     CookieDescriptor[] TASK_TOKEN_COOKIE_DESCRIPTORS = {
-        cookieWithName("Access-Token").description("인증 토큰")
+        cookieWithName("dg_sess").description("인증 토큰")
     };
 
     RequestCookiesSnippet TASK_ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(TASK_TOKEN_COOKIE_DESCRIPTORS);

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/LogoutDocumentationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/LogoutDocumentationTest.java
@@ -14,8 +14,8 @@ import static project.dailyge.app.test.user.documentationtest.snippet.UserSnippe
 @DisplayName("[DocumentationTest] 로그아웃 API 문서화 테스트")
 class LogoutDocumentationTest extends DatabaseTestBase {
 
-    private static final String ACCESS_TOKEN = "Access-Token";
-    private static final String REFRESH_TOKEN = "Refresh-Token";
+    private static final String ACCESS_TOKEN = "dg_sess";
+    private static final String REFRESH_TOKEN = "dg_res";
 
     @Test
     @DisplayName("[RestDocs] 로그아웃을 하면, 200 OK 응답을 받는다.")
@@ -62,7 +62,7 @@ class LogoutDocumentationTest extends DatabaseTestBase {
 
         given(this.specification)
             .filter(filter)
-            .cookie("Access-Token", "ABCD")
+            .cookie("dg_sess", "ABCD")
             .contentType(APPLICATION_JSON_VALUE)
             .when()
             .post("/api/logout")

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserDeleteDocumentationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserDeleteDocumentationTest.java
@@ -18,8 +18,8 @@ import static project.dailyge.app.test.user.documentationtest.snippet.UserSnippe
 @DisplayName("[DocumentationTest] 유저 삭제 API 문서화 테스트")
 class UserDeleteDocumentationTest extends DatabaseTestBase {
 
-    private static final String ACCESS_TOKEN = "Access-Token";
-    private static final String REFRESH_TOKEN = "Refresh-Token";
+    private static final String ACCESS_TOKEN = "dg_sess";
+    private static final String REFRESH_TOKEN = "dg_res";
 
     @Autowired
     private UserWriteService userWriteService;

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserReadDocumentationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserReadDocumentationTest.java
@@ -77,7 +77,7 @@ class UserReadDocumentationTest extends DatabaseTestBase {
         given(this.specification)
             .filter(filter)
             .contentType(APPLICATION_JSON_VALUE)
-            .cookie("Access-Token", "ABCD")
+            .cookie("dg_sess", "ABCD")
             .when()
             .get("/api/users/{userId}", Long.MAX_VALUE)
             .then()

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserUpdateDocumentationTest.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/UserUpdateDocumentationTest.java
@@ -20,8 +20,6 @@ import static project.dailyge.app.test.user.documentationtest.snippet.UserUpdate
 @DisplayName("[DocumentationTest] 유저 수정 API 문서화 테스트")
 class UserUpdateDocumentationTest extends DatabaseTestBase {
 
-    private static final String ACCESS_TOKEN = "Access-Token";
-    private static final String REFRESH_TOKEN = "Refresh-Token";
     private UserUpdateRequest request;
 
     @BeforeEach

--- a/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/snippet/UserSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/user/documentationtest/snippet/UserSnippet.java
@@ -25,7 +25,7 @@ public interface UserSnippet {
     String TAG = "User";
 
     CookieDescriptor[] USER_ACCESS_TOKEN_COOKIE_DESCRIPTOR = {
-        cookieWithName("Access-Token").description("사용자 토큰 쿠키")
+        cookieWithName("dg_sess").description("사용자 토큰 쿠키")
     };
 
     RequestCookiesSnippet USER_ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(USER_ACCESS_TOKEN_COOKIE_DESCRIPTOR);
@@ -62,9 +62,9 @@ public interface UserSnippet {
     };
 
     CookieDescriptor[] USER_DELETE_RESPONSE_COOKIE_DESCRIPTOR = {
-        cookieWithName("Access-Token").description("만료 된 인증 토큰"),
-        cookieWithName("Refresh-Token").description("만료 된 리프레시 토큰"),
-        cookieWithName("Logged-In").description("로그인 여부")
+        cookieWithName("dg_sess").description("만료 된 인증 토큰"),
+        cookieWithName("dg_res").description("만료 된 리프레시 토큰"),
+        cookieWithName("logged_in").description("로그인 여부")
     };
 
     FieldDescriptor[] LOGIN_PAGE_FIELD_DESCRIPTOR = {
@@ -74,9 +74,9 @@ public interface UserSnippet {
     };
 
     CookieDescriptor[] LOGOUT_RESPONSE_COOKIE_DESCRIPTOR = {
-        cookieWithName("Access-Token").description("만료 된 인증 토큰"),
-        cookieWithName("Refresh-Token").description("만료 된 리프레시 토큰"),
-        cookieWithName("Logged-In").description("로그인 여부")
+        cookieWithName("dg_sess").description("만료 된 인증 토큰"),
+        cookieWithName("dg_res").description("만료 된 리프레시 토큰"),
+        cookieWithName("logged_in").description("로그인 여부")
     };
 
     FieldDescriptor[] RESPONSE_STATUS = {

--- a/dailyge-api/src/test/java/project/dailyge/app/test/weeklygoal/documentationtest/snippet/WeeklyGoalSnippet.java
+++ b/dailyge-api/src/test/java/project/dailyge/app/test/weeklygoal/documentationtest/snippet/WeeklyGoalSnippet.java
@@ -28,7 +28,7 @@ public interface WeeklyGoalSnippet {
     String identifier = "{class_name}/{method_name}/";
 
     CookieDescriptor[] WEEKLY_GOAL_TOKEN_COOKIE_DESCRIPTORS = {
-        cookieWithName("Access-Token").description("인증 토큰")
+        cookieWithName("dg_sess").description("인증 토큰")
     };
 
     RequestCookiesSnippet WEEKLY_GOAL_ACCESS_TOKEN_COOKIE_SNIPPET = requestCookies(WEEKLY_GOAL_TOKEN_COOKIE_DESCRIPTORS);


### PR DESCRIPTION
## 📝 작업 내용

이번 작업은 [JWT 이름을 클라이언트에 어떻게 저장하는 것이 좋을까?](https://github.com/dailyge/dailyge-server/discussions/136)에서 다같이 토론을 통해 결정되었던 인증 쿠키의 명칭으로 변경하는 작업을 반영해보려고 합니다.

- [X] 인증 관련 쿠키 명칭 변경
- [X] 테스트 코드 수정

<br/><br/>

## 📌 상세 내용
인증 관련 변경되는 Cookie의 정보는 아래와 같습니다.
- `Access-Token` -> `dg_sess`
- `Refresh-Token` -> `dg_res`
- `Logged-In` -> `logged_in`



<br/><br/>


## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-387)
