### PR TITLE
[DLG-389] 회원가입 시, 닉네임 정규식을 수정한다.

### DIFF
--- a/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
@@ -19,7 +19,7 @@ public class UserJpaEntity extends BaseEntity {
     private static final int MAX_NICKNAME_LENGTH = 24;
     private static final int MAX_PROFILE_IMAGE_URL_LENGTH = 2000;
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[0-9a-zA-Z]+(?:[._-]?[0-9a-zA-Z]+)*@gmail\\.com$");
-    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣._-](?:[a-zA-Z0-9가-힣._\\s-]{2,23})$");
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣._-](?:[a-zA-Z0-9가-힣._\\s-]{2,24})$");
     private static final String OVER_MAX_NICKNAME_LENGTH_ERROR_MESSAGE = "입력 가능한 최대 닉네임 길이를 초과했습니다.";
     private static final String INVALID_EMAIL_ERROR_MESSAGE = "유효하지 않는 이메일 형식입니다.";
     private static final String OVER_MAX_PROFILE_IMAGE_URL_ERROR_MESSAGE = "입력 가능한 최대 URL 길이를 초과했습니다.";

--- a/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
@@ -19,7 +19,7 @@ public class UserJpaEntity extends BaseEntity {
     private static final int MAX_NICKNAME_LENGTH = 24;
     private static final int MAX_PROFILE_IMAGE_URL_LENGTH = 2000;
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[0-9a-zA-Z]+(?:[._-]?[0-9a-zA-Z]+)*@gmail\\.com$");
-    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣._-](?:[a-zA-Z0-9가-힣._\\s-]{2,24})$");
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣._-][a-zA-Z0-9가-힣._\\s-]{2,24}$");
     private static final String OVER_MAX_NICKNAME_LENGTH_ERROR_MESSAGE = "입력 가능한 최대 닉네임 길이를 초과했습니다.";
     private static final String INVALID_EMAIL_ERROR_MESSAGE = "유효하지 않는 이메일 형식입니다.";
     private static final String OVER_MAX_PROFILE_IMAGE_URL_ERROR_MESSAGE = "입력 가능한 최대 URL 길이를 초과했습니다.";

--- a/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/user/UserJpaEntity.java
@@ -19,7 +19,7 @@ public class UserJpaEntity extends BaseEntity {
     private static final int MAX_NICKNAME_LENGTH = 24;
     private static final int MAX_PROFILE_IMAGE_URL_LENGTH = 2000;
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[0-9a-zA-Z]+(?:[._-]?[0-9a-zA-Z]+)*@gmail\\.com$");
-    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣._-]{3,24}$");
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣._-](?:[a-zA-Z0-9가-힣._\\s-]{2,23})$");
     private static final String OVER_MAX_NICKNAME_LENGTH_ERROR_MESSAGE = "입력 가능한 최대 닉네임 길이를 초과했습니다.";
     private static final String INVALID_EMAIL_ERROR_MESSAGE = "유효하지 않는 이메일 형식입니다.";
     private static final String OVER_MAX_PROFILE_IMAGE_URL_ERROR_MESSAGE = "입력 가능한 최대 URL 길이를 초과했습니다.";

--- a/storage/rdb/src/test/java/project/dailyge/entity/test/user/UserJpaEntityUnitTest.java
+++ b/storage/rdb/src/test/java/project/dailyge/entity/test/user/UserJpaEntityUnitTest.java
@@ -1,18 +1,17 @@
 package project.dailyge.entity.test.user;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-import project.dailyge.entity.user.UserJpaEntity;
-
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import project.dailyge.entity.user.UserJpaEntity;
 
 @DisplayName("[UnitTest] UserJPAEntity 단위 테스트")
 class UserJpaEntityUnitTest {
@@ -98,11 +97,18 @@ class UserJpaEntityUnitTest {
 
     @ParameterizedTest
     @DisplayName("닉네임에 허용되지 않는 특수 문자가 포함될 경우 IllegalArgumentException이 발생한다.")
-    @ValueSource(strings = {"nick*name", "user@name", "hello!", "name$", "with space"})
+    @ValueSource(strings = {"nick*name", "user@name", "hello!", "name$"})
     void whenNicknameContainsInvalidCharactersThenIllegalArgumentExceptionShouldBeHappen(final String nickname) {
         assertThatThrownBy(() -> new UserJpaEntity(1L, nickname, EMAIL))
             .isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessage("올바른 닉네임을 입력해주세요.");
+    }
+
+    @ParameterizedTest
+    @DisplayName("닉네임에 공백이 있어도 ")
+    @ValueSource(strings = {"nickname Jung", "user af", "hello Jung Jung"})
+    void whenNicknameContainsSpaceThenResultShouldBeOk(final String nickname) {
+        assertNotNull(new UserJpaEntity(1L, nickname, EMAIL));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## 📝 작업 내용

닉네임에 공백이 있을 시, 회원가입이 되지 않는 이슈가 있어 공백을 허용하도록 수정했습니다.

- [x] 닉네임 공백 포함하도록 정규식 수정
- [x] 테스트 케이스 보강

<br/><br/>

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-389)
