### PR TITLE
[DLG-393] Serializable를 도입한 객체에 serial version UID를 추가한다.

### DIFF
--- a/dailyge-api/src/main/java/project/dailyge/app/core/note/application/NoteReadService.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/note/application/NoteReadService.java
@@ -15,9 +15,5 @@ public interface NoteReadService {
 
     List<NoteJpaEntity> findReceivedNotesById(DailygeUser dailygeUser, Cursor cursor);
 
-    NoteJpaEntity findReceivedNoteById(Long userId, Long noteId);
-
-    NoteJpaEntity findSentNoteById(Long userId, Long noteId);
-
     List<NoteJpaEntity> findAll();
 }

--- a/dailyge-api/src/main/java/project/dailyge/app/core/task/application/usecase/TaskValidator.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/task/application/usecase/TaskValidator.java
@@ -1,19 +1,20 @@
 package project.dailyge.app.core.task.application.usecase;
 
 import org.springframework.stereotype.Component;
-import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.UN_AUTHORIZED;
 import project.dailyge.app.common.exception.CommonException;
 import project.dailyge.app.core.common.auth.DailygeUser;
-import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.MONTHLY_TASK_EXISTS;
-import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TOO_MANY_TASKS;
-import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TOO_MANY_TASK_LABELS;
 import project.dailyge.app.core.task.exception.TaskTypeException;
 import project.dailyge.entity.task.MonthlyTaskEntityReadRepository;
 import project.dailyge.entity.task.TaskEntityReadRepository;
 import project.dailyge.entity.task.TaskJpaEntity;
+import project.dailyge.entity.task.TaskLabelEntityReadRepository;
 
 import java.time.LocalDate;
-import project.dailyge.entity.task.TaskLabelEntityReadRepository;
+
+import static project.dailyge.app.codeandmessage.CommonCodeAndMessage.UN_AUTHORIZED;
+import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.MONTHLY_TASK_EXISTS;
+import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TOO_MANY_TASKS;
+import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TOO_MANY_TASK_LABELS;
 
 @Component
 public class TaskValidator {
@@ -30,14 +31,6 @@ public class TaskValidator {
         this.monthlyTaskReadRepository = monthlyTaskReadRepository;
         this.taskReadRepository = taskReadRepository;
         this.taskLabelEntityReadRepository = taskLabelEntityReadRepository;
-    }
-
-    public TaskValidator(
-        final MonthlyTaskEntityReadRepository monthlyTaskReadRepository,
-        final TaskEntityReadRepository taskReadRepository
-    ) {
-        this.monthlyTaskReadRepository = monthlyTaskReadRepository;
-        this.taskReadRepository = taskReadRepository;
     }
 
     public void validateAuth(

--- a/dailyge-api/src/main/java/project/dailyge/app/core/task/application/usecase/TaskWriteUseCase.java
+++ b/dailyge-api/src/main/java/project/dailyge/app/core/task/application/usecase/TaskWriteUseCase.java
@@ -8,21 +8,22 @@ import project.dailyge.app.core.task.application.command.TaskCreateCommand;
 import project.dailyge.app.core.task.application.command.TaskLabelCreateCommand;
 import project.dailyge.app.core.task.application.command.TaskStatusUpdateCommand;
 import project.dailyge.app.core.task.application.command.TaskUpdateCommand;
-import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.MONTHLY_TASK_NOT_FOUND;
-import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TASK_NOT_FOUND;
 import project.dailyge.app.core.task.exception.TaskTypeException;
 import project.dailyge.entity.task.MonthlyTaskEntityReadRepository;
 import project.dailyge.entity.task.MonthlyTaskEntityWriteRepository;
 import project.dailyge.entity.task.MonthlyTaskJpaEntity;
-import static project.dailyge.entity.task.MonthlyTasks.createMonthlyTasks;
 import project.dailyge.entity.task.TaskEntityReadRepository;
 import project.dailyge.entity.task.TaskEntityWriteRepository;
 import project.dailyge.entity.task.TaskJpaEntity;
+import project.dailyge.entity.task.TaskLabelEntityWriteRepository;
+import project.dailyge.entity.task.TaskLabelJpaEntity;
 
 import java.time.LocalDate;
 import java.util.List;
-import project.dailyge.entity.task.TaskLabelEntityWriteRepository;
-import project.dailyge.entity.task.TaskLabelJpaEntity;
+
+import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.MONTHLY_TASK_NOT_FOUND;
+import static project.dailyge.app.core.task.exception.TaskCodeAndMessage.TASK_NOT_FOUND;
+import static project.dailyge.entity.task.MonthlyTasks.createMonthlyTasks;
 
 @ApplicationLayer(value = "TaskWriteUseCase")
 class TaskWriteUseCase implements TaskWriteService {
@@ -48,20 +49,6 @@ class TaskWriteUseCase implements TaskWriteService {
         this.monthlyTaskReadRepository = monthlyTaskReadRepository;
         this.monthlyTaskWriteRepository = monthlyTaskWriteRepository;
         this.taskLabelEntityWriteRepository = taskLabelEntityWriteRepository;
-    }
-
-    public TaskWriteUseCase(
-        final TaskValidator validator,
-        final TaskEntityReadRepository taskReadRepository,
-        final TaskEntityWriteRepository taskWriteRepository,
-        final MonthlyTaskEntityReadRepository monthlyTaskReadRepository,
-        final MonthlyTaskEntityWriteRepository monthlyTaskWriteRepository
-    ) {
-        this.validator = validator;
-        this.taskReadRepository = taskReadRepository;
-        this.taskWriteRepository = taskWriteRepository;
-        this.monthlyTaskReadRepository = monthlyTaskReadRepository;
-        this.monthlyTaskWriteRepository = monthlyTaskWriteRepository;
     }
 
     @Override

--- a/storage/memory/src/main/java/project/dailyge/core/cache/coupon/CouponEvent.java
+++ b/storage/memory/src/main/java/project/dailyge/core/cache/coupon/CouponEvent.java
@@ -1,9 +1,13 @@
 package project.dailyge.core.cache.coupon;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
 public class CouponEvent implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
     private Long userId;
     private Long timestamp;
 

--- a/storage/memory/src/main/java/project/dailyge/core/cache/coupon/CouponEvent.java
+++ b/storage/memory/src/main/java/project/dailyge/core/cache/coupon/CouponEvent.java
@@ -8,6 +8,7 @@ public class CouponEvent implements Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
+
     private Long userId;
     private Long timestamp;
 

--- a/storage/memory/src/main/java/project/dailyge/core/cache/user/UserCache.java
+++ b/storage/memory/src/main/java/project/dailyge/core/cache/user/UserCache.java
@@ -1,9 +1,13 @@
 package project.dailyge.core.cache.user;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Objects;
 
 public class UserCache implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     private Long id;
     private String nickname;

--- a/storage/rdb/src/main/java/project/dailyge/entity/task/TaskJpaEntity.java
+++ b/storage/rdb/src/main/java/project/dailyge/entity/task/TaskJpaEntity.java
@@ -63,9 +63,6 @@ public class TaskJpaEntity extends BaseEntity {
     @Column(name = "task_recurrence_id")
     private Long taskRecurrenceId;
 
-    @Column(name = "task_recurrence_id")
-    private Long taskRecurrenceId;
-
     protected TaskJpaEntity() {
     }
 


### PR DESCRIPTION
## 📝 작업 내용

[DLG-393] Serializable를 도입한 객체에 serial version UID를 추가합니다.
- [X] Serializable를 도입한 객체에 serial version UID 추가.

<br/><br/>

## 📌 상세 내용

현재 프로젝트에서 Redis에 객체를 저장할 때 바이트 스트림으로 변환하여 메모리를 효율적으로 사용하기 위해 직렬화해서 저장하고 있습니다. 이때 serial Version UID를 지정하지 않으면 컴파일러가 자동으로 생성시키고 클래스 구조가 변경되면 자동으로 생성된 UID 값이 변경되어 직렬화된 데이터를 읽으려 할 때 예외가 발생합니다. 특히 분산 시스템에서 클래스 필드와 타입이 동일해도 serial version UID가 다르면 변환 시 예외가 발생할 수 있기 때문에 이를 방지하고자 수정했습니다.

## 🔗 이슈 트래킹
- [Ticket](https://jungjunwoojun.atlassian.net/jira/software/projects/DLG/boards/4?selectedIssue=DLG-393)


[DLG-393]: https://jungjunwoojun.atlassian.net/browse/DLG-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ